### PR TITLE
fix: preserve input_image parts in chat bridge | 修复 chat 桥接丢失图片

### DIFF
--- a/src/chat-bridge.mjs
+++ b/src/chat-bridge.mjs
@@ -109,8 +109,17 @@ function inputToChatMessages(input, reasoningLookup) {
       continue;
     }
     if (item?.role === "user") {
-      const text = typeof item.content === "string" ? item.content : Array.isArray(item.content) ? item.content.map((part) => part?.text || "").join("") : "";
-      if (text) out.push({ role: "user", content: text });
+      const isArray = Array.isArray(item.content);
+      const text = typeof item.content === "string" ? item.content : isArray ? item.content.map((part) => part?.text || "").join("") : "";
+      const imageParts = isArray ? item.content.filter((part) => part?.type === "input_image" && typeof part?.image_url === "string") : [];
+      if (text && imageParts.length === 0) {
+        out.push({ role: "user", content: text });
+      } else if (text || imageParts.length > 0) {
+        const content = [];
+        if (text) content.push({ type: "text", text });
+        for (const img of imageParts) content.push({ type: "image_url", image_url: { url: img.image_url } });
+        out.push({ role: "user", content });
+      }
       index += 1;
       continue;
     }


### PR DESCRIPTION
## Problem
`inputToChatMessages` (chat-bridge.mjs) dropped every non-text part of user content — `input_image` attachments were silently discarded.

## Impact
Vision turns routed through the chat camp (opencode-go profile, e.g. direct-vision route to mimo-v2.5) reached the vision model with **no image attached**, producing empty or hallucinated answers. Repro: POST a request with `input_image` to `/v1/responses` while the target model is chat-camp; the vision model responds it cannot see any image.

## Fix
Keep `input_image` parts and convert them to chat-dialect `image_url` parts alongside the flattened text. Existing text-only behavior unchanged (44/44 tests pass, including chat-bridge and transform suites).

## Verification
- `node --test src/chat-bridge.test.mjs src/transform.test.mjs` → 44 pass
- End-to-end: `deepseek-v4-flash` + red PNG → routed to `mimo-v2.5` → answers "红色" (previously: no image seen)

---
## 问题
chat-bridge.mjs 的 inputToChatMessages 在转换 user 消息时只保留 text 部分，input_image 图片被静默丢弃。

## 影响
走 chat camp（opencode-go profile，如 direct-vision 路由到 mimo-v2.5）的视觉轮次到达视觉模型时没有任何图片，产生空答案或幻觉。复现：向 /v1/responses 发送带 input_image 的请求，目标模型为 chat camp，视觉模型回复看不到任何图片。

## 修复
保留 input_image 部分，与文本一起转换为 chat 方言的 image_url 部分。纯文本行为不变（44/44 测试通过，含 chat-bridge 与 transform 套件）。

## 验证
- node --test src/chat-bridge.test.mjs src/transform.test.mjs → 44 pass
- 端到端：deepseek-v4-flash + 红色 PNG → 路由到 mimo-v2.5 → 回答「红色」（修复前：看不到图片）