### PR TITLE
feat: gate native GPT merge on ChatGPT sign-in; fix compaction failure telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/server.mjs",
     "dev": "node --watch src/server.mjs",
-    "test": "node --test test/*.test.mjs src/autostart.test.mjs src/catalog.test.mjs src/config.test.mjs src/caller-key.test.mjs src/config-switcher.test.mjs src/error-translation.test.mjs src/gateway.test.mjs src/instance-owner.test.mjs src/mcp-server.test.mjs src/mcp-standalone.test.mjs src/media-store.test.mjs src/memory.test.mjs src/metrics.test.mjs src/native-catalog.test.mjs src/profiles.test.mjs src/router.test.mjs src/secrets.test.mjs src/server-gateway.test.mjs src/server.test.mjs src/update.test.mjs src/upstreams.test.mjs src/usage-events.test.mjs",
+    "test": "node --test test/*.test.mjs src/*.test.mjs",
     "test:install": "node --test test/install-mock.test.mjs test/install-macos-sim.test.mjs",
     "probe:live": "node scripts/live-probe.mjs",
     "build": "node scripts/build.mjs",

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -187,6 +187,24 @@ function discoverCodexGoToken(codexHome) {
   return { token: "", source: "missing" };
 }
 
+// Does the Codex home directory carry a ChatGPT/Codex sign-in (auth.json)?
+// ModelDock never holds native credentials itself: it forwards whatever headers
+// the Codex client sends, so a missing sign-in means every published native GPT
+// model answers 401. Detecting the sign-in here lets the published catalog skip
+// the native merge for logged-out users instead of advertising dead models.
+// A refresh token is treated as a sign-in too (Codex refreshes it silently).
+export function hasChatGptLogin(codexHome) {
+  try {
+    const authFile = path.join(codexHome, "auth.json");
+    if (!existsSync(authFile)) return false;
+    const parsed = JSON.parse(readFileSync(authFile, "utf8"));
+    const tokens = parsed?.tokens || {};
+    return Boolean(tokens.access_token || tokens.refresh_token || parsed?.OPENAI_API_KEY);
+  } catch {
+    return false;
+  }
+}
+
 export function loadConfig() {
   applyEnvFile(envFileFor());
   const host = process.env.MODELDOCK_HOST || "127.0.0.1";
@@ -225,9 +243,16 @@ export function loadConfig() {
   // GPT to fall back on, so both keep the free vision model unless explicitly
   // overridden via MODELDOCK_VISION_MODEL.
   const trialMode = process.env.MODELDOCK_TRIAL === "1";
-  const nativeMerge = !["0", "false", "off"].includes(
-    String(process.env.MODELDOCK_NATIVE_MERGE || "").toLowerCase(),
-  );
+  // Wizard-managed native-GPT merge: off for users without a ChatGPT/Codex
+  // subscription so the picker never advertises models that 401 on request.
+  // Defaults to the signed-in state when the env key is unset: a detected
+  // ~/.codex/auth.json keeps the merge (subscriber behavior unchanged), no
+  // sign-in means the native GPT models stay out of the published catalog.
+  const nativeMerge = (() => {
+    const raw = String(process.env.MODELDOCK_NATIVE_MERGE || "").toLowerCase();
+    if (raw) return !["0", "false", "off"].includes(raw);
+    return hasChatGptLogin(codexHome);
+  })();
   const defaultVisionModel = trialMode || !nativeMerge ? "mimo-v2.5-free" : "gpt-5.6-luna";
   const visionModel = modelRef(process.env.MODELDOCK_VISION_MODEL || defaultVisionModel);
   const visionFallbackModel = modelRef(process.env.MODELDOCK_VISION_FALLBACK_MODEL || "minimax-m3");
@@ -270,7 +295,7 @@ export function loadConfig() {
     trialMode,
     // Wizard-managed native-GPT merge: off for users without a ChatGPT/Codex
     // subscription so the picker never advertises models that 401 on request.
-    // Defaults to on (current behavior) when the env key is unset.
+    // Defaults to the signed-in state when the env key is unset (see above).
     nativeMerge,
     mcpTransport,
     visionTimeoutMs: integer("MODELDOCK_VISION_TIMEOUT_MS", 90_000, { min: 1_000, max: 300_000 }),

--- a/src/config.test.mjs
+++ b/src/config.test.mjs
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { loadConfig, tokenFromCodexToml } from "./config.mjs";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { loadConfig, hasChatGptLogin, tokenFromCodexToml } from "./config.mjs";
 
 test("reads an OpenCode bearer token only from a supported provider section", () => {
   const source = `
@@ -30,5 +33,52 @@ test("zenBaseUrl resolves from MODELDOCK_ZEN_BASE_URL with the trailing slash no
   } finally {
     if (previous === undefined) delete process.env.MODELDOCK_ZEN_BASE_URL;
     else process.env.MODELDOCK_ZEN_BASE_URL = previous;
+  }
+});
+
+test("nativeMerge defaults to the ChatGPT sign-in state when MODELDOCK_NATIVE_MERGE is unset", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "modeldock-config-auth-"));
+  const previousHome = process.env.MODELDOCK_CODEX_HOME;
+  const previousMerge = process.env.MODELDOCK_NATIVE_MERGE;
+  const previousEnvFile = process.env.MODELDOCK_ENV_FILE;
+  process.env.MODELDOCK_CODEX_HOME = home;
+  process.env.MODELDOCK_ENV_FILE = path.join(home, "isolated.env");
+  try {
+    assert.equal(loadConfig().nativeMerge, false, "no ChatGPT sign-in means native GPT models stay unpublished");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: { access_token: "sk-test" } }), "utf8");
+    assert.equal(loadConfig().nativeMerge, true, "a detected sign-in keeps the subscriber-native merge");
+    process.env.MODELDOCK_NATIVE_MERGE = "0";
+    assert.equal(loadConfig().nativeMerge, false, "MODELDOCK_NATIVE_MERGE=0 overrides a detected sign-in");
+    delete process.env.MODELDOCK_NATIVE_MERGE;
+    process.env.MODELDOCK_NATIVE_MERGE = "1";
+    rmSync(path.join(home, "auth.json"), { force: true });
+    assert.equal(loadConfig().nativeMerge, true, "MODELDOCK_NATIVE_MERGE=1 overrides a missing sign-in");
+  } finally {
+    if (previousHome === undefined) delete process.env.MODELDOCK_CODEX_HOME;
+    else process.env.MODELDOCK_CODEX_HOME = previousHome;
+    if (previousMerge === undefined) delete process.env.MODELDOCK_NATIVE_MERGE;
+    else process.env.MODELDOCK_NATIVE_MERGE = previousMerge;
+    if (previousEnvFile === undefined) delete process.env.MODELDOCK_ENV_FILE;
+    else process.env.MODELDOCK_ENV_FILE = previousEnvFile;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hasChatGptLogin requires a real token and ignores malformed files", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "modeldock-config-auth2-"));
+  try {
+    assert.equal(hasChatGptLogin(home), false, "no auth.json means no sign-in");
+    writeFileSync(path.join(home, "auth.json"), "{}", "utf8");
+    assert.equal(hasChatGptLogin(home), false, "an empty tokens object is not a sign-in");
+    writeFileSync(path.join(home, "auth.json"), "not json", "utf8");
+    assert.equal(hasChatGptLogin(home), false, "a malformed file is not a sign-in");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ OPENAI_API_KEY: "sk-test" }), "utf8");
+    assert.equal(hasChatGptLogin(home), true, "the legacy OPENAI_API_KEY shape counts");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: { refresh_token: "r-test" } }), "utf8");
+    assert.equal(hasChatGptLogin(home), true, "a refresh token counts (Codex refreshes it silently)");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: {} }), "utf8");
+    assert.equal(hasChatGptLogin(home), false, "an empty tokens object is not a sign-in");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
   }
 });

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -1198,7 +1198,7 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
         httpStatus: upstream.status,
         upstream: target.provider,
         error: translated.body.error.message.slice(0, 400),
-        requestShape: describeInputShape(normalizedPayload.input),
+        requestShape: describeInputShape(payload.input),
       });
       metrics?.recordResponseTransform?.({
         blocked: { tool_search: 0, web_search: 0 },

--- a/src/gateway.test.mjs
+++ b/src/gateway.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Writable } from "node:stream";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
 import {
   RouteAffinity,
   applyToolPolicy,
@@ -1162,6 +1165,58 @@ test("relayResponses counts the request body bytes as transfer-in", async () => 
     assert.equal(transformOptions[0].streaming, true);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayCompaction reports the failure telemetry when the upstream rejects the summarize call", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const finishes = [];
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-compact-state-"));
+  const previousStateDir = process.env.MODELDOCK_STATE_DIR;
+  process.env.MODELDOCK_STATE_DIR = stateDir;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(
+    JSON.stringify({ error: { message: "invalid_api_key", type: "invalid_request_error" } }),
+    { status: 401, headers: { "content-type": "application/json" } },
+  );
+  try {
+    const result = await relayCompaction(
+      {
+        model: "deepseek-v4-flash",
+        stream: false,
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+          { type: "compaction_trigger" },
+        ],
+      },
+      res,
+      {
+        ...compactServices(),
+        metrics: {
+          begin: () => (telemetry) => finishes.push(telemetry),
+          recordResponseUsage: () => {},
+        },
+      },
+      {},
+      true,
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.httpStatus, 401, "the upstream 401 is reported, not a swallowed 502");
+    assert.equal(finishes.length, 1, "the failure finish fires exactly once");
+    assert.equal(finishes[0].httpStatus, 401);
+    assert.deepEqual(
+      finishes[0].requestShape.itemTypes,
+      { message: 1, compaction_trigger: 1 },
+      "the request shape rides the failure telemetry",
+    );
+    const body = JSON.parse(Buffer.concat(sink.chunks).toString("utf8"));
+    assert.equal(body.error.type, "auth_failed", "the 401 is translated into the auth_failed class");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousStateDir === undefined) delete process.env.MODELDOCK_STATE_DIR;
+    else process.env.MODELDOCK_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
   }
 });
 

--- a/src/vision-eval.mjs
+++ b/src/vision-eval.mjs
@@ -1,7 +1,12 @@
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-export const VISION_ASSETS_DIR = "D:/projects/modeldock/assets/vision";
+// The benchmark images ship inside the repo (assets/vision). The old hardcoded
+// developer path (D:/projects/...) broke every other checkout; default to the
+// repo-relative layout, overridable for mirrored deployments.
+export const VISION_ASSETS_DIR = process.env.MODELDOCK_VISION_ASSETS_DIR
+  || resolve(dirname(fileURLToPath(import.meta.url)), "..", "assets", "vision");
 
 const VERBATIM = " Answer directly and briefly, no explanation.";
 


### PR DESCRIPTION
> **Update 1 (2026-08-09):** rebased onto upstream `main` at `81de474` (v0.2.0). Clean rebase — no conflicts. The credential-aware `nativeMerge` semantics are preserved and **complement the wizard's explicit `MODELDOCK_NATIVE_MERGE` switch**: explicit env wins, unset falls back to detected sign-in state. `npm test`: **261/261** (was 254).
>
> **Update 2 (2026-08-09):** synced two merge-hygiene fixes so this branch is safe to merge before or after any of #6-#11:
> - `fix: make vision eval assets dir repo-relative` (4ea675d) — the hardcoded `D:/projects` path in `src/vision-eval.mjs` (a #8 fix) now lands on every PR branch, so skipping #8 no longer lets the developer-machine path into main.
> - `perf: discover tests by glob instead of a hand-maintained list` (a15fd70) — `test` script is now `node --test test/*.test.mjs src/*.test.mjs` (node --test expands the glob itself, matching only files that exist), so #7/#8/#9/#11 no longer collide on the test-script line when merged in any order. `npm test`: **261/261**.
>
> **Update 3 (2026-08-09):** rebased onto v0.2.1 (`cc0dd74`, +4 upstream commits: memory habits in base instructions / permissive recall fallback / wizard translations / version bump). Clean rebase, no conflicts (upstream's `55d6666` touched `catalog.mjs` base instructions; this branch does not modify that file). `npm test`: **264/264**.

Two changes for logged-out users and the compaction failure path.

## 1. Native GPT merge is now credential-aware (`src/config.mjs`)

`mergeNativeCatalog` unconditionally published native GPT models, so a user without a ChatGPT/Codex sign-in saw models in the picker that answered 401 on every request (no signed-in headers to forward).

- `hasChatGptLogin(codexHome)` detects `~/.codex/auth.json` (access token, refresh token, or the legacy `OPENAI_API_KEY` shape; malformed files count as logged-out).
- With `MODELDOCK_NATIVE_MERGE` unset, `nativeMerge` now **defaults to the detected sign-in state** instead of always on: subscribers keep the merge, logged-out users get the curated catalog only (no dead GPT entries).
- An explicit `MODELDOCK_NATIVE_MERGE=1/0` still wins over detection. This is deliberately complementary to the upstream wizard's `nativeMerge` switch (cbc9b03 / 82b426a): the wizard manages the explicit flag for the four account combinations, while the default (env unset) now tracks reality instead of assuming a subscription — a logged-out user who never opens the wizard no longer sees models that 401.

## 2. Fix `relayCompaction` failure-path ReferenceError (`src/gateway.mjs`)

The failure branch referenced `normalizedPayload`, a `relayResponses`-only variable; `relayCompaction` has `payload`. The ReferenceError was swallowed by the generic catch, so a failed compact request lost its request-shape telemetry and surfaced as a generic 502 instead of the upstream status.

- `normalizedPayload.input` → `payload.input`
- The failure finish now records `requestShape` and the upstream `httpStatus` (e.g. 401 translated into the `auth_failed` class).

## Tests

- `hasChatGptLogin`: no file / empty tokens / malformed JSON → false; access token, refresh token, `OPENAI_API_KEY` → true
- `nativeMerge` default: no sign-in → off, sign-in → on, explicit env override wins in both directions
- `relayCompaction` failure path: upstream 401 is reported as such (not a swallowed 502), the failure finish fires exactly once with `requestShape`

`npm test`: 264/264 passing.