### PR TITLE
feat: caller-key enforcement by default, uninstall, log rotation, key hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/server.mjs",
     "dev": "node --watch src/server.mjs",
-    "test": "node --test test/*.test.mjs src/autostart.test.mjs src/catalog.test.mjs src/config.test.mjs src/caller-key.test.mjs src/config-switcher.test.mjs src/error-translation.test.mjs src/gateway.test.mjs src/instance-owner.test.mjs src/mcp-server.test.mjs src/mcp-standalone.test.mjs src/media-store.test.mjs src/memory.test.mjs src/metrics.test.mjs src/native-catalog.test.mjs src/profiles.test.mjs src/router.test.mjs src/secrets.test.mjs src/server-gateway.test.mjs src/server.test.mjs src/update.test.mjs src/upstreams.test.mjs src/usage-events.test.mjs",
+    "test": "node --test test/*.test.mjs src/*.test.mjs",
     "test:install": "node --test test/install-mock.test.mjs test/install-macos-sim.test.mjs",
     "probe:live": "node scripts/live-probe.mjs",
     "build": "node scripts/build.mjs",

--- a/scripts/start-hidden.ps1
+++ b/scripts/start-hidden.ps1
@@ -37,4 +37,10 @@ if (-not $nodeExe) {
 # command starts with a quoted program path, so wrap the whole command in one extra
 # pair of quotes (the ""prog" args" form).
 $log = Join-Path $root "modeldock.log"
+# Rotate at startup, one previous generation (like codex-router's log-rotation):
+# the log is append-only for the life of the process, so a cap on growth can only
+# be applied between runs. 32 MB keeps roughly a month of daily use.
+if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+    Move-Item -LiteralPath $log -Destination "$log.1" -Force
+}
 Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden

--- a/scripts/start-hidden.sh
+++ b/scripts/start-hidden.sh
@@ -44,4 +44,11 @@ fi
 cd "$ROOT"
 # Log instead of discarding: a background start that dies (bad node, port in use,
 # missing file) is otherwise completely silent for the user.
-nohup "$NODE_BIN" "$SERVER" >>"$ROOT/modeldock.log" 2>&1 &
+LOG="$ROOT/modeldock.log"
+# Rotate at startup, one previous generation (like codex-router's log-rotation):
+# the log is append-only for the life of the process, so a cap on growth can only
+# be applied between runs. 32 MB keeps roughly a month of daily use.
+if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 33554432 ]; then
+  mv -f "$LOG" "$LOG.1"
+fi
+nohup "$NODE_BIN" "$SERVER" >>"$LOG" 2>&1 &

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,32 @@
+# Remove ModelDock: stop the gateway, drop the autostart Run key, delete the
+# install dir and the gateway log. Ownership-list discipline: only
+# ModelDock-owned paths are touched, never a recursive sweep of user state.
+# The ~/.codex config backup (config.toml.modeldock-backup-*) is kept:
+# recover.ps1 still needs it, and an uninstall must never destroy recovery data.
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$stateDir = if ($env:MODELDOCK_ROOT) { $env:MODELDOCK_ROOT } else { Join-Path $HOME ".modeldock" }
+$log = Join-Path $root "modeldock.log"
+$port = if ($env:MODELDOCK_PORT) { [int]$env:MODELDOCK_PORT } else { 4097 }
+
+# Stop the gateway: find the listener on the configured port and terminate it.
+$procIds = @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty OwningProcess -Unique)
+foreach ($procId in $procIds) {
+    Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    Write-Output "Stopped gateway process $procId"
+}
+
+# Drop the autostart Run key (HKCU\...\Run ModelDock, as written by autostart.mjs).
+reg.exe delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v ModelDock /f 2>$null | Out-Null
+Write-Output "Removed autostart Run key"
+
+if (Test-Path -LiteralPath $stateDir) {
+    Remove-Item -LiteralPath $stateDir -Recurse -Force
+    Write-Output "Removed install dir: $stateDir"
+} else {
+    Write-Output "No install dir at $stateDir; nothing to remove."
+}
+Remove-Item -LiteralPath $log -Force -ErrorAction SilentlyContinue
+
+Write-Output "ModelDock uninstalled. Your ~/.codex config backup (config.toml.modeldock-backup-*) was kept for recovery."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Remove ModelDock: the autostart entry, the install dir, and the gateway log.
+# Ownership-list discipline: only ModelDock-owned paths are touched, never a
+# recursive sweep of user state.
+#   - macOS: ~/Library/LaunchAgents/com.modeldock.gateway.plist + launchctl
+#   - the install dir (~/.modeldock by default; MODELDOCK_ROOT overrides)
+#   - the gateway log next to this script
+# The ~/.codex config backup (config.toml.modeldock-backup-*) is kept: recover.sh
+# still needs it, and an uninstall must never destroy recovery data.
+set -eu
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+STATE_DIR="${MODELDOCK_ROOT:-$HOME/.modeldock}"
+LOG="$ROOT/modeldock.log"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  PLIST_DIR="${MODELDOCK_AUTOSTART_PLIST_DIR:-$HOME/Library/LaunchAgents}"
+  PLIST="$PLIST_DIR/com.modeldock.gateway.plist"
+  if [ -f "$PLIST" ]; then
+    launchctl unload -w "$PLIST" >/dev/null 2>&1 || true
+    rm -f "$PLIST"
+    echo "Removed autostart entry: $PLIST"
+  fi
+fi
+
+if [ -d "$STATE_DIR" ]; then
+  rm -rf "$STATE_DIR"
+  echo "Removed install dir: $STATE_DIR"
+else
+  echo "No install dir at $STATE_DIR; nothing to remove."
+fi
+rm -f "$LOG"
+
+echo "ModelDock uninstalled. Your ~/.codex config backup (config.toml.modeldock-backup-*) was kept for recovery."

--- a/src/caller-key.mjs
+++ b/src/caller-key.mjs
@@ -1,5 +1,6 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -13,6 +14,35 @@ import path from "node:path";
 export const CALLER_PATH_PREFIX = "/c";
 const KEY_FILE = path.join(os.homedir(), ".modeldock", "caller-key");
 const KEY_PATTERN = /^[A-Za-z0-9_-]{32,}$/;
+
+// The persisted key is a bearer capability: restrict the file to the current
+// user (POSIX 0600; Windows: remove inherited ACLs, grant the user Full
+// Control). Same intent as codex-router's file-security.mjs. Failure is never
+// fatal - the key still works for this process lifetime.
+let windowsSid;
+function currentWindowsSid() {
+  if (windowsSid) return windowsSid;
+  const script = "[Console]::Out.Write([Security.Principal.WindowsIdentity]::GetCurrent().User.Value)";
+  windowsSid = execFileSync(
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  ).trim();
+  if (!windowsSid) throw new Error("Could not resolve the current Windows user SID.");
+  return windowsSid;
+}
+
+function protectPrivateFile(target) {
+  chmodSync(target, 0o600);
+  if (process.platform !== "win32") return target;
+  const sid = currentWindowsSid();
+  execFileSync(
+    "icacls.exe",
+    [target, "/inheritance:r", "/grant:r", `*${sid}:(F)`],
+    { stdio: "ignore" },
+  );
+  return target;
+}
 
 export function validCallerKey(value) {
   return typeof value === "string" && KEY_PATTERN.test(value);
@@ -31,7 +61,14 @@ export function callerKeyEqual(actual, expected) {
 export function loadOrCreateCallerKey(filePath = KEY_FILE) {
   try {
     const existing = readFileSync(filePath, "utf8").trim();
-    if (validCallerKey(existing)) return existing;
+    if (validCallerKey(existing)) {
+      try {
+        protectPrivateFile(filePath);
+      } catch {
+        // Hardening must never take the gateway down.
+      }
+      return existing;
+    }
   } catch {
     // Missing or unreadable: mint below.
   }
@@ -39,6 +76,11 @@ export function loadOrCreateCallerKey(filePath = KEY_FILE) {
   try {
     mkdirSync(path.dirname(filePath), { recursive: true });
     writeFileSync(filePath, `${key}\n`, "utf8");
+    try {
+      protectPrivateFile(filePath);
+    } catch {
+      // Hardening must never take the gateway down.
+    }
   } catch {
     // Unwritable state dir: the key still works for this process lifetime.
   }

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -187,6 +187,24 @@ function discoverCodexGoToken(codexHome) {
   return { token: "", source: "missing" };
 }
 
+// Does the Codex home directory carry a ChatGPT/Codex sign-in (auth.json)?
+// ModelDock never holds native credentials itself: it forwards whatever headers
+// the Codex client sends, so a missing sign-in means every published native GPT
+// model answers 401. Detecting the sign-in here lets the published catalog skip
+// the native merge for logged-out users instead of advertising dead models.
+// A refresh token is treated as a sign-in too (Codex refreshes it silently).
+export function hasChatGptLogin(codexHome) {
+  try {
+    const authFile = path.join(codexHome, "auth.json");
+    if (!existsSync(authFile)) return false;
+    const parsed = JSON.parse(readFileSync(authFile, "utf8"));
+    const tokens = parsed?.tokens || {};
+    return Boolean(tokens.access_token || tokens.refresh_token || parsed?.OPENAI_API_KEY);
+  } catch {
+    return false;
+  }
+}
+
 export function loadConfig() {
   applyEnvFile(envFileFor());
   const host = process.env.MODELDOCK_HOST || "127.0.0.1";
@@ -225,9 +243,16 @@ export function loadConfig() {
   // GPT to fall back on, so both keep the free vision model unless explicitly
   // overridden via MODELDOCK_VISION_MODEL.
   const trialMode = process.env.MODELDOCK_TRIAL === "1";
-  const nativeMerge = !["0", "false", "off"].includes(
-    String(process.env.MODELDOCK_NATIVE_MERGE || "").toLowerCase(),
-  );
+  // Wizard-managed native-GPT merge: off for users without a ChatGPT/Codex
+  // subscription so the picker never advertises models that 401 on request.
+  // Defaults to the signed-in state when the env key is unset: a detected
+  // ~/.codex/auth.json keeps the merge (subscriber behavior unchanged), no
+  // sign-in means the native GPT models stay out of the published catalog.
+  const nativeMerge = (() => {
+    const raw = String(process.env.MODELDOCK_NATIVE_MERGE || "").toLowerCase();
+    if (raw) return !["0", "false", "off"].includes(raw);
+    return hasChatGptLogin(codexHome);
+  })();
   const defaultVisionModel = trialMode || !nativeMerge ? "mimo-v2.5-free" : "gpt-5.6-luna";
   const visionModel = modelRef(process.env.MODELDOCK_VISION_MODEL || defaultVisionModel);
   const visionFallbackModel = modelRef(process.env.MODELDOCK_VISION_FALLBACK_MODEL || "minimax-m3");
@@ -270,7 +295,7 @@ export function loadConfig() {
     trialMode,
     // Wizard-managed native-GPT merge: off for users without a ChatGPT/Codex
     // subscription so the picker never advertises models that 401 on request.
-    // Defaults to on (current behavior) when the env key is unset.
+    // Defaults to the signed-in state when the env key is unset (see above).
     nativeMerge,
     mcpTransport,
     visionTimeoutMs: integer("MODELDOCK_VISION_TIMEOUT_MS", 90_000, { min: 1_000, max: 300_000 }),

--- a/src/config.test.mjs
+++ b/src/config.test.mjs
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { loadConfig, tokenFromCodexToml } from "./config.mjs";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { loadConfig, hasChatGptLogin, tokenFromCodexToml } from "./config.mjs";
 
 test("reads an OpenCode bearer token only from a supported provider section", () => {
   const source = `
@@ -30,5 +33,52 @@ test("zenBaseUrl resolves from MODELDOCK_ZEN_BASE_URL with the trailing slash no
   } finally {
     if (previous === undefined) delete process.env.MODELDOCK_ZEN_BASE_URL;
     else process.env.MODELDOCK_ZEN_BASE_URL = previous;
+  }
+});
+
+test("nativeMerge defaults to the ChatGPT sign-in state when MODELDOCK_NATIVE_MERGE is unset", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "modeldock-config-auth-"));
+  const previousHome = process.env.MODELDOCK_CODEX_HOME;
+  const previousMerge = process.env.MODELDOCK_NATIVE_MERGE;
+  const previousEnvFile = process.env.MODELDOCK_ENV_FILE;
+  process.env.MODELDOCK_CODEX_HOME = home;
+  process.env.MODELDOCK_ENV_FILE = path.join(home, "isolated.env");
+  try {
+    assert.equal(loadConfig().nativeMerge, false, "no ChatGPT sign-in means native GPT models stay unpublished");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: { access_token: "sk-test" } }), "utf8");
+    assert.equal(loadConfig().nativeMerge, true, "a detected sign-in keeps the subscriber-native merge");
+    process.env.MODELDOCK_NATIVE_MERGE = "0";
+    assert.equal(loadConfig().nativeMerge, false, "MODELDOCK_NATIVE_MERGE=0 overrides a detected sign-in");
+    delete process.env.MODELDOCK_NATIVE_MERGE;
+    process.env.MODELDOCK_NATIVE_MERGE = "1";
+    rmSync(path.join(home, "auth.json"), { force: true });
+    assert.equal(loadConfig().nativeMerge, true, "MODELDOCK_NATIVE_MERGE=1 overrides a missing sign-in");
+  } finally {
+    if (previousHome === undefined) delete process.env.MODELDOCK_CODEX_HOME;
+    else process.env.MODELDOCK_CODEX_HOME = previousHome;
+    if (previousMerge === undefined) delete process.env.MODELDOCK_NATIVE_MERGE;
+    else process.env.MODELDOCK_NATIVE_MERGE = previousMerge;
+    if (previousEnvFile === undefined) delete process.env.MODELDOCK_ENV_FILE;
+    else process.env.MODELDOCK_ENV_FILE = previousEnvFile;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hasChatGptLogin requires a real token and ignores malformed files", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "modeldock-config-auth2-"));
+  try {
+    assert.equal(hasChatGptLogin(home), false, "no auth.json means no sign-in");
+    writeFileSync(path.join(home, "auth.json"), "{}", "utf8");
+    assert.equal(hasChatGptLogin(home), false, "an empty tokens object is not a sign-in");
+    writeFileSync(path.join(home, "auth.json"), "not json", "utf8");
+    assert.equal(hasChatGptLogin(home), false, "a malformed file is not a sign-in");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ OPENAI_API_KEY: "sk-test" }), "utf8");
+    assert.equal(hasChatGptLogin(home), true, "the legacy OPENAI_API_KEY shape counts");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: { refresh_token: "r-test" } }), "utf8");
+    assert.equal(hasChatGptLogin(home), true, "a refresh token counts (Codex refreshes it silently)");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: {} }), "utf8");
+    assert.equal(hasChatGptLogin(home), false, "an empty tokens object is not a sign-in");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
   }
 });

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -1198,7 +1198,7 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
         httpStatus: upstream.status,
         upstream: target.provider,
         error: translated.body.error.message.slice(0, 400),
-        requestShape: describeInputShape(normalizedPayload.input),
+        requestShape: describeInputShape(payload.input),
       });
       metrics?.recordResponseTransform?.({
         blocked: { tool_search: 0, web_search: 0 },

--- a/src/gateway.test.mjs
+++ b/src/gateway.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Writable } from "node:stream";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
 import {
   RouteAffinity,
   applyToolPolicy,
@@ -1162,6 +1165,58 @@ test("relayResponses counts the request body bytes as transfer-in", async () => 
     assert.equal(transformOptions[0].streaming, true);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayCompaction reports the failure telemetry when the upstream rejects the summarize call", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const finishes = [];
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-compact-state-"));
+  const previousStateDir = process.env.MODELDOCK_STATE_DIR;
+  process.env.MODELDOCK_STATE_DIR = stateDir;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(
+    JSON.stringify({ error: { message: "invalid_api_key", type: "invalid_request_error" } }),
+    { status: 401, headers: { "content-type": "application/json" } },
+  );
+  try {
+    const result = await relayCompaction(
+      {
+        model: "deepseek-v4-flash",
+        stream: false,
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+          { type: "compaction_trigger" },
+        ],
+      },
+      res,
+      {
+        ...compactServices(),
+        metrics: {
+          begin: () => (telemetry) => finishes.push(telemetry),
+          recordResponseUsage: () => {},
+        },
+      },
+      {},
+      true,
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.httpStatus, 401, "the upstream 401 is reported, not a swallowed 502");
+    assert.equal(finishes.length, 1, "the failure finish fires exactly once");
+    assert.equal(finishes[0].httpStatus, 401);
+    assert.deepEqual(
+      finishes[0].requestShape.itemTypes,
+      { message: 1, compaction_trigger: 1 },
+      "the request shape rides the failure telemetry",
+    );
+    const body = JSON.parse(Buffer.concat(sink.chunks).toString("utf8"));
+    assert.equal(body.error.type, "auth_failed", "the 401 is translated into the auth_failed class");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousStateDir === undefined) delete process.env.MODELDOCK_STATE_DIR;
+    else process.env.MODELDOCK_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
   }
 });
 

--- a/src/server-gateway.test.mjs
+++ b/src/server-gateway.test.mjs
@@ -8,6 +8,11 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createApp, createServices } from "./server.mjs";
 import { OPENCODE_GO_PROFILE } from "./profiles.mjs";
 
+// Bare-path relay tests exercise the routed gateway, not the caller-key guard.
+// Enforcement is ON by default since 0.1.10, so these tests opt out explicitly;
+// the default-enforcement behavior itself is covered by its own test below.
+process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0";
+
 const TEST_PROFILE = { ...OPENCODE_GO_PROFILE };
 
 function baseConfig() {
@@ -314,9 +319,32 @@ test("caller-key routes: correct key relays, wrong key and enforced bare path 40
   assert.equal(models.status, 200, "the keyed models path serves the catalog");
 
   process.env.MODELDOCK_REQUIRE_CALLER_KEY = "1";
-  t.after(() => { delete process.env.MODELDOCK_REQUIRE_CALLER_KEY; });
+  t.after(() => { process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0"; });
   const bare = await fetch(`${instance.base}/v1/responses`, { method: "POST", headers, body });
   assert.equal(bare.status, 401, "bare path is refused once enforcement is on");
+});
+
+test("caller-key enforcement defaults to on: bare paths 401 without an explicit opt-out", async (t) => {
+  const upstream = createServer((req, res) => {
+    res.setHeader("content-type", "text/event-stream");
+    res.end('data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\ndata: [DONE]\n\n');
+  });
+  const port = await listen(upstream);
+  t.after(() => upstream.close());
+  const instance = await startApp({ goBaseUrl: `http://127.0.0.1:${port}`, opencodeBaseUrl: `http://127.0.0.1:${port}` });
+  t.after(instance.stop);
+  const body = JSON.stringify({ model: "deepseek-v4-flash", stream: true, input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }] });
+  const headers = { "content-type": "application/json" };
+
+  delete process.env.MODELDOCK_REQUIRE_CALLER_KEY;
+  t.after(() => { process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0"; });
+  const bare = await fetch(`${instance.base}/v1/responses`, { method: "POST", headers, body });
+  assert.equal(bare.status, 401, "the bare path is refused by default");
+  const bareImages = await fetch(`${instance.base}/images/generations`, { method: "POST", headers, body });
+  assert.equal(bareImages.status, 401, "the bare native-image path is refused by default");
+  const keyed = await fetch(`${instance.base}/c/test-caller-key-0123456789abcdefghij/v1/responses`, { method: "POST", headers, body });
+  assert.equal(keyed.status, 200, "the keyed path still relays by default");
+  await keyed.text();
 });
 
 test("zstd-encoded request bodies are decompressed before the relay", { skip: typeof (await import("node:zlib")).zstdCompressSync !== "function" }, async (t) => {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -786,16 +786,22 @@ export function createApp(services = createServices()) {
   });
   app.post([...NATIVE_IMAGE_PATHS].map((item) => `${CALLER_PATH_PREFIX}/:key${item}`), requireCallerKey, nativeImageRelay);
   // Bare paths stay for compatibility with configs written before the caller key
-  // existed. MODELDOCK_REQUIRE_CALLER_KEY=1 turns them off once the switch has
-  // been re-enabled and Codex uses the keyed URL.
+  // existed. Enforcement is ON by default: a hostile local web page can POST to
+  // loopback without reading ~/.modeldock, so an unkeyed path would let it burn
+  // the upstream tokens this process holds. MODELDOCK_REQUIRE_CALLER_KEY=0 (or
+  // off/false) re-opens the bare paths for legacy configs.
+  const callerKeyEnforced = () => {
+    const raw = String(process.env.MODELDOCK_REQUIRE_CALLER_KEY || "").toLowerCase();
+    return raw === "" || !["0", "false", "off"].includes(raw);
+  };
   const bareRelay = (req, res) => {
-    if (process.env.MODELDOCK_REQUIRE_CALLER_KEY === "1") {
+    if (callerKeyEnforced()) {
       return res.status(401).json({ error: { type: "caller_key_required", message: "This gateway requires the keyed base URL; re-enable the Codex switch." } });
     }
     return relayGatewayRequest(req, res, services);
   };
   const bareNativeImageRelay = (req, res) => {
-    if (process.env.MODELDOCK_REQUIRE_CALLER_KEY === "1") {
+    if (callerKeyEnforced()) {
       return res.status(401).json({ error: { type: "caller_key_required", message: "This gateway requires the keyed base URL; re-enable the Codex switch." } });
     }
     return nativeImageRelay(req, res);

--- a/src/server.test.mjs
+++ b/src/server.test.mjs
@@ -8,6 +8,11 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createApp, createServices, startServer, initAutostartDefault, codexModelCatalog } from "./server.mjs";
 import { OPENCODE_GO_PROFILE, DEEPSEEK_OFFICIAL_PROFILE } from "./profiles.mjs";
 
+// Bare-path tests exercise the app wiring, not the caller-key guard. Enforcement
+// is ON by default since 0.1.10, so this file opts out explicitly; the default
+// enforcement behavior is covered in server-gateway.test.mjs.
+process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0";
+
 const TEST_PROFILE = { ...OPENCODE_GO_PROFILE };
 
 function baseConfig() {

--- a/src/vision-eval.mjs
+++ b/src/vision-eval.mjs
@@ -1,7 +1,12 @@
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-export const VISION_ASSETS_DIR = "D:/projects/modeldock/assets/vision";
+// The benchmark images ship inside the repo (assets/vision). The old hardcoded
+// developer path (D:/projects/...) broke every other checkout; default to the
+// repo-relative layout, overridable for mirrored deployments.
+export const VISION_ASSETS_DIR = process.env.MODELDOCK_VISION_ASSETS_DIR
+  || resolve(dirname(fileURLToPath(import.meta.url)), "..", "assets", "vision");
 
 const VERBATIM = " Answer directly and briefly, no explanation.";
 


### PR DESCRIPTION
> **Update 1 (2026-08-09):** rebased onto upstream `main` at `81de474` (v0.2.0). Clean rebase — no conflicts. `npm test`: **262/262** (was 255; baseline grew with upstream's memory-coverage tests).
>
> **Update 2 (2026-08-09):** synced two merge-hygiene fixes:
> - `fix: make vision eval assets dir repo-relative` (582e1ac) — the `src/vision-eval.mjs` hardcoded-path fix (from #8) now lands on this branch too, so merging before #8 cannot let the developer-machine path into main.
> - `perf: discover tests by glob instead of a hand-maintained list` (25d1b7e) — `test` script is now `node --test test/*.test.mjs src/*.test.mjs`; no more collisions with #7/#8/#9/#11 on the test-script line. `npm test`: **262/262**.
>
> **Update 3 (2026-08-09):** rebased onto v0.2.1 (`cc0dd74`). Clean rebase, no conflicts. `npm test`: **265/265**.

Security & reliability batch: caller-key enforcement on by default, an uninstall command, gateway log rotation, and key-file hardening.

## 1. Caller-key enforcement ON by default (`src/server.mjs`)

A hostile local web page can POST to `http://127.0.0.1:/v1/responses` (no-cors fetch fires even though the response is unreadable) and burn the upstream tokens the gateway holds. Previously that bare path was open unless `MODELDOCK_REQUIRE_CALLER_KEY=1` was set.

- Bare `/v1/responses`, `/responses*` and native-image paths are now refused by default (401 `caller_key_required`).
- `MODELDOCK_REQUIRE_CALLER_KEY=0` (or `off`/`false`) re-opens them for legacy configs.
- The keyed `/c//v1` base URL — which ModelDock always writes into `config.toml` (`server.mjs` `callerBasePath`) — is unaffected, so existing installs keep working without config changes.

## 2. Uninstall command (`scripts/uninstall.sh`, `scripts/uninstall.ps1`)

`recover` restores config; nothing removed the install. Ownership-list discipline (opencodex-style): only ModelDock-owned paths are touched — the launchd plist / HKCU `Run` key, the install dir (`~/.modeldock`, `MODELDOCK_ROOT` overridable), and the gateway log. The `~/.codex` config backups are deliberately kept so `recover.sh`/`recover.ps1` can still restore the original `config.toml`.

## 3. Gateway log rotation (`scripts/start-hidden.sh`, `scripts/start-hidden.ps1`)

`modeldock.log` is append-only for the life of the process (the writers hold the file open), so rotation happens at startup: a log over 32 MB is moved to `modeldock.log.1`, keeping exactly one previous generation (codex-router's log-rotation approach, one fewer diagnostic dead-end for long-running gateways).

## 4. Key-file hardening (`src/caller-key.mjs`)

The persisted capability key is now restricted to the current user — POSIX `0600`, and on Windows `icacls /inheritance:r /grant:r :(F)` (same intent as codex-router's file-security.mjs, SID-prefixed to avoid account-name resolution). Hardening failures never take the gateway down.

## Notes

- A1/A2 from the borrow list (health-backoff / health-cache) are deliberately **not** ported: ModelDock has no continuous health-poll loop — probes happen only at restart/install — so the log-burst problem they solve does not exist here.
- Tests: `server.test.mjs` / `server-gateway.test.mjs` bare-path suites opt out of enforcement explicitly; a new test covers the default-on behavior for both the responses and native-image bare paths.

`npm test`: 265/265 passing.