### PR TITLE
feat: 10-point doctor diagnostic (node scripts/doctor.mjs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/server.mjs",
     "dev": "node --watch src/server.mjs",
-    "test": "node --test test/*.test.mjs src/autostart.test.mjs src/catalog.test.mjs src/config.test.mjs src/caller-key.test.mjs src/config-switcher.test.mjs src/doctor.test.mjs src/error-translation.test.mjs src/gateway.test.mjs src/instance-owner.test.mjs src/mcp-server.test.mjs src/mcp-standalone.test.mjs src/media-store.test.mjs src/memory.test.mjs src/metrics.test.mjs src/native-catalog.test.mjs src/profiles.test.mjs src/router.test.mjs src/secrets.test.mjs src/server-gateway.test.mjs src/server.test.mjs src/update.test.mjs src/upstreams.test.mjs src/usage-events.test.mjs",
+    "test": "node --test test/*.test.mjs src/*.test.mjs",
     "test:install": "node --test test/install-mock.test.mjs test/install-macos-sim.test.mjs",
     "probe:live": "node scripts/live-probe.mjs",
     "build": "node scripts/build.mjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/server.mjs",
     "dev": "node --watch src/server.mjs",
-    "test": "node --test test/*.test.mjs src/autostart.test.mjs src/catalog.test.mjs src/config.test.mjs src/caller-key.test.mjs src/config-switcher.test.mjs src/error-translation.test.mjs src/gateway.test.mjs src/instance-owner.test.mjs src/mcp-server.test.mjs src/mcp-standalone.test.mjs src/media-store.test.mjs src/memory.test.mjs src/metrics.test.mjs src/native-catalog.test.mjs src/profiles.test.mjs src/router.test.mjs src/secrets.test.mjs src/server-gateway.test.mjs src/server.test.mjs src/update.test.mjs src/upstreams.test.mjs src/usage-events.test.mjs",
+    "test": "node --test test/*.test.mjs src/autostart.test.mjs src/catalog.test.mjs src/config.test.mjs src/caller-key.test.mjs src/config-switcher.test.mjs src/doctor.test.mjs src/error-translation.test.mjs src/gateway.test.mjs src/instance-owner.test.mjs src/mcp-server.test.mjs src/mcp-standalone.test.mjs src/media-store.test.mjs src/memory.test.mjs src/metrics.test.mjs src/native-catalog.test.mjs src/profiles.test.mjs src/router.test.mjs src/secrets.test.mjs src/server-gateway.test.mjs src/server.test.mjs src/update.test.mjs src/upstreams.test.mjs src/usage-events.test.mjs",
     "test:install": "node --test test/install-mock.test.mjs test/install-macos-sim.test.mjs",
     "probe:live": "node scripts/live-probe.mjs",
     "build": "node scripts/build.mjs",

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// ModelDock doctor CLI: prints the 10-point check list and exits 1 when any
+// check fails (warnings do not fail the run). Never prints credential values.
+//   node scripts/doctor.mjs          human-readable report
+//   node scripts/doctor.mjs --json   machine-readable { checks, exitCode }
+import { checkDoctor, doctorExitCode } from "../src/doctor.mjs";
+
+const jsonOutput = process.argv.includes("--json");
+
+const checks = await checkDoctor();
+const exitCode = doctorExitCode(checks);
+
+if (jsonOutput) {
+  process.stdout.write(JSON.stringify({ checks, exitCode }, null, 2) + "\n");
+} else {
+  for (const check of checks) {
+    const mark = check.status === "ok" ? "[ok]  " : check.status === "warn" ? "[warn]" : "[fail]";
+    process.stdout.write(`${mark} ${check.name}: ${check.detail}\n`);
+    if (check.fix) process.stdout.write(`       fix: ${check.fix}\n`);
+  }
+  process.stdout.write(`\n${checks.length} checks, ${checks.filter((c) => c.status === "fail").length} failed, ${checks.filter((c) => c.status === "warn").length} warnings\n`);
+}
+process.exit(exitCode);

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -187,6 +187,24 @@ function discoverCodexGoToken(codexHome) {
   return { token: "", source: "missing" };
 }
 
+// Does the Codex home directory carry a ChatGPT/Codex sign-in (auth.json)?
+// ModelDock never holds native credentials itself: it forwards whatever headers
+// the Codex client sends, so a missing sign-in means every published native GPT
+// model answers 401. Detecting the sign-in here lets the published catalog skip
+// the native merge for logged-out users instead of advertising dead models.
+// A refresh token is treated as a sign-in too (Codex refreshes it silently).
+export function hasChatGptLogin(codexHome) {
+  try {
+    const authFile = path.join(codexHome, "auth.json");
+    if (!existsSync(authFile)) return false;
+    const parsed = JSON.parse(readFileSync(authFile, "utf8"));
+    const tokens = parsed?.tokens || {};
+    return Boolean(tokens.access_token || tokens.refresh_token || parsed?.OPENAI_API_KEY);
+  } catch {
+    return false;
+  }
+}
+
 export function loadConfig() {
   applyEnvFile(envFileFor());
   const host = process.env.MODELDOCK_HOST || "127.0.0.1";
@@ -225,9 +243,16 @@ export function loadConfig() {
   // GPT to fall back on, so both keep the free vision model unless explicitly
   // overridden via MODELDOCK_VISION_MODEL.
   const trialMode = process.env.MODELDOCK_TRIAL === "1";
-  const nativeMerge = !["0", "false", "off"].includes(
-    String(process.env.MODELDOCK_NATIVE_MERGE || "").toLowerCase(),
-  );
+  // Wizard-managed native-GPT merge: off for users without a ChatGPT/Codex
+  // subscription so the picker never advertises models that 401 on request.
+  // Defaults to the signed-in state when the env key is unset: a detected
+  // ~/.codex/auth.json keeps the merge (subscriber behavior unchanged), no
+  // sign-in means the native GPT models stay out of the published catalog.
+  const nativeMerge = (() => {
+    const raw = String(process.env.MODELDOCK_NATIVE_MERGE || "").toLowerCase();
+    if (raw) return !["0", "false", "off"].includes(raw);
+    return hasChatGptLogin(codexHome);
+  })();
   const defaultVisionModel = trialMode || !nativeMerge ? "mimo-v2.5-free" : "gpt-5.6-luna";
   const visionModel = modelRef(process.env.MODELDOCK_VISION_MODEL || defaultVisionModel);
   const visionFallbackModel = modelRef(process.env.MODELDOCK_VISION_FALLBACK_MODEL || "minimax-m3");
@@ -270,7 +295,7 @@ export function loadConfig() {
     trialMode,
     // Wizard-managed native-GPT merge: off for users without a ChatGPT/Codex
     // subscription so the picker never advertises models that 401 on request.
-    // Defaults to on (current behavior) when the env key is unset.
+    // Defaults to the signed-in state when the env key is unset (see above).
     nativeMerge,
     mcpTransport,
     visionTimeoutMs: integer("MODELDOCK_VISION_TIMEOUT_MS", 90_000, { min: 1_000, max: 300_000 }),

--- a/src/config.test.mjs
+++ b/src/config.test.mjs
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { loadConfig, tokenFromCodexToml } from "./config.mjs";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { loadConfig, hasChatGptLogin, tokenFromCodexToml } from "./config.mjs";
 
 test("reads an OpenCode bearer token only from a supported provider section", () => {
   const source = `
@@ -30,5 +33,52 @@ test("zenBaseUrl resolves from MODELDOCK_ZEN_BASE_URL with the trailing slash no
   } finally {
     if (previous === undefined) delete process.env.MODELDOCK_ZEN_BASE_URL;
     else process.env.MODELDOCK_ZEN_BASE_URL = previous;
+  }
+});
+
+test("nativeMerge defaults to the ChatGPT sign-in state when MODELDOCK_NATIVE_MERGE is unset", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "modeldock-config-auth-"));
+  const previousHome = process.env.MODELDOCK_CODEX_HOME;
+  const previousMerge = process.env.MODELDOCK_NATIVE_MERGE;
+  const previousEnvFile = process.env.MODELDOCK_ENV_FILE;
+  process.env.MODELDOCK_CODEX_HOME = home;
+  process.env.MODELDOCK_ENV_FILE = path.join(home, "isolated.env");
+  try {
+    assert.equal(loadConfig().nativeMerge, false, "no ChatGPT sign-in means native GPT models stay unpublished");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: { access_token: "sk-test" } }), "utf8");
+    assert.equal(loadConfig().nativeMerge, true, "a detected sign-in keeps the subscriber-native merge");
+    process.env.MODELDOCK_NATIVE_MERGE = "0";
+    assert.equal(loadConfig().nativeMerge, false, "MODELDOCK_NATIVE_MERGE=0 overrides a detected sign-in");
+    delete process.env.MODELDOCK_NATIVE_MERGE;
+    process.env.MODELDOCK_NATIVE_MERGE = "1";
+    rmSync(path.join(home, "auth.json"), { force: true });
+    assert.equal(loadConfig().nativeMerge, true, "MODELDOCK_NATIVE_MERGE=1 overrides a missing sign-in");
+  } finally {
+    if (previousHome === undefined) delete process.env.MODELDOCK_CODEX_HOME;
+    else process.env.MODELDOCK_CODEX_HOME = previousHome;
+    if (previousMerge === undefined) delete process.env.MODELDOCK_NATIVE_MERGE;
+    else process.env.MODELDOCK_NATIVE_MERGE = previousMerge;
+    if (previousEnvFile === undefined) delete process.env.MODELDOCK_ENV_FILE;
+    else process.env.MODELDOCK_ENV_FILE = previousEnvFile;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hasChatGptLogin requires a real token and ignores malformed files", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "modeldock-config-auth2-"));
+  try {
+    assert.equal(hasChatGptLogin(home), false, "no auth.json means no sign-in");
+    writeFileSync(path.join(home, "auth.json"), "{}", "utf8");
+    assert.equal(hasChatGptLogin(home), false, "an empty tokens object is not a sign-in");
+    writeFileSync(path.join(home, "auth.json"), "not json", "utf8");
+    assert.equal(hasChatGptLogin(home), false, "a malformed file is not a sign-in");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ OPENAI_API_KEY: "sk-test" }), "utf8");
+    assert.equal(hasChatGptLogin(home), true, "the legacy OPENAI_API_KEY shape counts");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: { refresh_token: "r-test" } }), "utf8");
+    assert.equal(hasChatGptLogin(home), true, "a refresh token counts (Codex refreshes it silently)");
+    writeFileSync(path.join(home, "auth.json"), JSON.stringify({ tokens: {} }), "utf8");
+    assert.equal(hasChatGptLogin(home), false, "an empty tokens object is not a sign-in");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
   }
 });

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -1,0 +1,191 @@
+// Doctor: a 10-point diagnostic for a ModelDock installation, in the spirit of
+// codex-router's doctor.mjs but scoped to what ModelDock can actually answer.
+// Never prints credential material: token presence is a yes/no, .env values are
+// only classified as encrypted vs plaintext. Every path is injectable so the
+// test suite can run the checks against a scratch install.
+import os from "node:os";
+import path from "node:path";
+import { existsSync, readFileSync, statSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { envFileFor, parseEnvFile, tokenFromCodexToml, hasChatGptLogin } from "./config.mjs";
+import { SECRET_KEYS, PREFIX as SECRET_PREFIX } from "./secrets.mjs";
+
+export const DOCTOR_CHECKS = 10;
+
+export async function checkDoctor({
+  port = Number(process.env.MODELDOCK_PORT || 4097),
+  stateDir = process.env.MODELDOCK_STATE_DIR || path.join(os.homedir(), ".modeldock"),
+  codexHome = path.resolve(process.env.MODELDOCK_CODEX_HOME || process.env.CODEX_HOME || path.join(os.homedir(), ".codex")),
+  envFile = process.env.MODELDOCK_ENV_FILE || envFileFor(),
+  rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), ".."),
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const checks = [];
+  const add = (status, name, detail, fix = "") => checks.push({ status, name, detail, fix });
+
+  // 1. Node.js
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  add(
+    major > 22 || (major === 22 && minor >= 0) ? "ok" : "fail",
+    "Node.js",
+    `${process.version}; Node 22+ required`,
+    "Install Node.js 22 LTS or newer, then restart the gateway.",
+  );
+
+  // 2. Service health on the configured port.
+  const probe = async () => {
+    try {
+      const res = await fetchImpl(`http://127.0.0.1:${port}/healthz`, { signal: AbortSignal.timeout(3_000) });
+      if (res.status !== 200) return { status: "fail", detail: `port ${port} answers ${res.status}, expected 200` };
+      const body = await res.json().catch(() => ({}));
+      return body.ok
+        ? { status: "ok", detail: `http://127.0.0.1:${port}/healthz answers ok` }
+        : { status: "warn", detail: `gateway is up but reports no provider token (/healthz ok=false)` };
+    } catch (error) {
+      return { status: "fail", detail: `nothing answers on 127.0.0.1:${port} (${error?.cause?.code || error?.message || error})` };
+    }
+  };
+  const health = await probe();
+  add(
+    health.status,
+    "Gateway health",
+    health.detail,
+    health.status === "fail"
+      ? "Start the gateway (scripts/start-hidden.sh / start-hidden.ps1, or the dashboard); check MODELDOCK_PORT matches."
+      : "",
+  );
+
+  // 3. ChatGPT sign-in (native GPT models depend on it).
+  const signedIn = hasChatGptLogin(codexHome);
+  add(
+    signedIn ? "ok" : "warn",
+    "ChatGPT sign-in",
+    signedIn ? "~/.codex/auth.json carries a session" : "no ~/.codex/auth.json; native GPT models are unpublished",
+    "Sign in to Codex/ChatGPT if you want native GPT models in the picker; logged-out installs work with routed providers.",
+  );
+
+  // 4. OpenCode Go token.
+  const codexConfig = path.join(codexHome, "config.toml");
+  const goToken = process.env.OPENCODE_GO_TOKEN || (existsSync(codexConfig) ? tokenFromCodexToml(readFileSync(codexConfig, "utf8")) : "");
+  add(
+    goToken ? "ok" : "warn",
+    "OpenCode Go token",
+    goToken ? "configured (env or codex config backup)" : "not configured",
+    "Add OPENCODE_GO_TOKEN to the .env (Settings) or start Codex once so the config backup carries the token.",
+  );
+
+  // 5. .env secret hygiene (never print values, only encryption state).
+  if (existsSync(envFile)) {
+    const entries = parseEnvFile(readFileSync(envFile, "utf8"));
+    const plainSecrets = Object.entries(entries).filter(
+      ([key, value]) => SECRET_KEYS.has(key) && value && !String(value).startsWith(SECRET_PREFIX),
+    );
+    add(
+      plainSecrets.length === 0 ? "ok" : "warn",
+      ".env secret storage",
+      plainSecrets.length === 0
+        ? "all secret keys are stored encrypted"
+        : `${plainSecrets.map(([key]) => key).join(", ")} stored in plaintext`,
+      process.platform === "win32"
+        ? "Run once with the settings API (it migrates plaintext secrets to DPAPI); on non-Windows plaintext is expected."
+        : "Plaintext is expected on non-Windows; keep the .env out of backups and sync tools.",
+    );
+  } else {
+    add("warn", ".env secret storage", "no .env file found", "The dashboard writes .env on first Settings save; this is expected before first run.");
+  }
+
+  // 6. State dir ownership (exists and writable).
+  const stateDirWritable = (() => {
+    if (!existsSync(stateDir)) return { ok: false, detail: `state dir missing: ${stateDir}` };
+    try {
+      const probe = mkdtempSync(path.join(stateDir, ".doctor-write-"));
+      rmSync(probe, { recursive: true, force: true });
+      return { ok: true, detail: stateDir };
+    } catch {
+      return { ok: false, detail: `state dir exists but is not writable: ${stateDir}` };
+    }
+  })();
+  add(
+    stateDirWritable.ok ? "ok" : "fail",
+    "State dir",
+    stateDirWritable.detail,
+    stateDirWritable.ok ? "" : "Create ~/.modeldock with the current user; the gateway cannot persist keys/state without it.",
+  );
+
+  // 7. Caller-key file: present and (on POSIX) 0600.
+  const callerKeyFile = path.join(stateDir, "caller-key");
+  if (existsSync(callerKeyFile)) {
+    const mode = statSync(callerKeyFile).mode & 0o777;
+    const protectedMode = process.platform === "win32" || mode === 0o600;
+    add(
+      protectedMode ? "ok" : "warn",
+      "Caller key file",
+      protectedMode
+        ? `present${process.platform === "win32" ? " (Windows ACL)" : ` (mode ${mode.toString(8)})`}`
+        : `present but world-readable (mode ${mode.toString(8)})`,
+      protectedMode ? "" : "Restrict it: chmod 600 (a second gateway start hardens it automatically).",
+    );
+  } else {
+    add("warn", "Caller key file", "not minted yet", "The gateway mints the key on first start; expected before the first run.");
+  }
+
+  // 8. Codex config route consistency: openai_base_url must point at this gateway.
+  const managedUrl = (() => {
+    if (!existsSync(codexConfig)) return "";
+    const match = readFileSync(codexConfig, "utf8").match(/^\s*openai_base_url\s*=\s*(.+?)\s*(?:#.*)?$/m);
+    if (!match) return "";
+    const raw = match[1].trim();
+    return raw.startsWith('"') && raw.endsWith('"') ? JSON.parse(raw) : raw;
+  })();
+  const routedToSelf = managedUrl.startsWith(`http://127.0.0.1:${port}`) || managedUrl.startsWith(`http://localhost:${port}`);
+  const keyed = routedToSelf && /\/c\/[^/]+\/v1$/.test(managedUrl);
+  add(
+    managedUrl === ""
+      ? "warn"
+      : keyed
+        ? "ok"
+        : routedToSelf
+          ? "warn"
+          : "warn",
+    "Codex route",
+    managedUrl === ""
+      ? "no openai_base_url found in config.toml (Codex not pointed at ModelDock)"
+      : keyed
+        ? `config.toml routes to this gateway: ${managedUrl}`
+        : `config.toml routes to ${managedUrl || "(elsewhere)"}, not this gateway's keyed URL`,
+    "Enable the Codex switch from the dashboard so config.toml is rewritten to the keyed /c/<key>/v1 URL.",
+  );
+
+  // 9. Install integrity: the bundle or the source entry exists.
+  const bundle = path.join(rootDir, "dist", "modeldock.mjs");
+  const sourceEntry = path.join(rootDir, "src", "server.mjs");
+  add(
+    existsSync(bundle) || existsSync(sourceEntry) ? "ok" : "fail",
+    "Installation",
+    existsSync(bundle) ? "release bundle present (dist/modeldock.mjs)" : existsSync(sourceEntry) ? "source checkout (src/server.mjs)" : "neither bundle nor source entry found",
+    "Re-run the installer, or npm run build in a checkout, so dist/modeldock.mjs exists.",
+  );
+
+  // 10. Log & diagnostics files.
+  const log = path.join(rootDir, "modeldock.log");
+  const compactFailures = path.join(stateDir, "compact-failures.jsonl");
+  const logNote = (() => {
+    if (!existsSync(log)) return "no log file yet";
+    const size = statSync(log).size;
+    return `${(size / 1024 / 1024).toFixed(1)} MB${size > 32 * 1024 * 1024 ? " (over the 32 MB rotation cap)" : ""}`;
+  })();
+  const failureNote = existsSync(compactFailures) ? "compact-failures.jsonl has history; review it" : "no recorded compact failures";
+  const logWarned = existsSync(log) && statSync(log).size > 32 * 1024 * 1024;
+  const failuresWarned = existsSync(compactFailures);
+  add(
+    logWarned || failuresWarned ? "warn" : "ok",
+    "Log & diagnostics",
+    `${logNote}; ${failureNote}`,
+    logWarned ? "Restart the gateway: start-hidden rotates modeldock.log once it exceeds 32 MB." : failuresWarned ? "Inspect ~/.modeldock/compact-failures.jsonl for repeated compaction upstream errors." : "",
+  );
+
+  return checks;
+}
+
+export function doctorExitCode(checks) {
+  return checks.some((check) => check.status === "fail") ? 1 : 0;
+}

--- a/src/doctor.test.mjs
+++ b/src/doctor.test.mjs
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, mkdirSync } from "node:fs";
+import { checkDoctor, doctorExitCode, DOCTOR_CHECKS } from "./doctor.mjs";
+
+function healthyFetch() {
+  return async () => new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+function makeEnv({ loggedIn = true, keyedRoute = true, plainSecret = false, callerMode = 0o600, fetchImpl = healthyFetch(), configToml = true } = {}) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "modeldock-doctor-"));
+  const stateDir = path.join(root, "state");
+  const codexHome = path.join(root, "codex");
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(codexHome, { recursive: true });
+  mkdirSync(path.join(root, "dist"), { recursive: true });
+  writeFileSync(path.join(root, "dist", "modeldock.mjs"), "// bundle", "utf8");
+  if (loggedIn) {
+    writeFileSync(path.join(codexHome, "auth.json"), JSON.stringify({ tokens: { access_token: "sk-test" } }), "utf8");
+  }
+  if (configToml) {
+    const route = keyedRoute
+      ? 'openai_base_url = "http://127.0.0.1:4097/c/somekey/v1"'
+      : 'openai_base_url = "https://api.openai.com/v1"';
+    writeFileSync(path.join(codexHome, "config.toml"), `model = "gpt-5.6-sol"\n${route}\n\n[model_providers.opencode_go]\nexperimental_bearer_token = "go-token"\n`, "utf8");
+  }
+  const envFile = path.join(root, "modeldock.env");
+  const secretLine = plainSecret ? "OPENCODE_GO_TOKEN=plain-token" : "OPENCODE_GO_TOKEN=dpapi:AAAA";
+  writeFileSync(envFile, `${secretLine}\nDEEPSEEK_API_KEY=\n`, "utf8");
+  const callerKeyFile = path.join(stateDir, "caller-key");
+  writeFileSync(callerKeyFile, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGH\n", "utf8");
+  chmodSync(callerKeyFile, callerMode);
+  return {
+    root,
+    stateDir,
+    codexHome,
+    envFile,
+    callerKeyFile,
+    options: { port: 4097, stateDir, codexHome, envFile, rootDir: root, fetchImpl },
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+test("a healthy install passes every check", async () => {
+  const env = makeEnv();
+  try {
+    const checks = await checkDoctor(env.options);
+    assert.equal(checks.length, DOCTOR_CHECKS);
+    for (const check of checks) {
+      assert.equal(check.status, "ok", `${check.name} should be ok: ${check.detail}`);
+    }
+    assert.equal(doctorExitCode(checks), 0);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("a stopped gateway fails the health check and the run", async () => {
+  const env = makeEnv({ fetchImpl: async () => { throw new Error("ECONNREFUSED"); } });
+  try {
+    const checks = await checkDoctor(env.options);
+    const health = checks.find((check) => check.name === "Gateway health");
+    assert.equal(health.status, "fail");
+    assert.match(health.detail, /nothing answers/);
+    assert.equal(doctorExitCode(checks), 1);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("a gateway without a provider token is a warning, not a failure", async () => {
+  const env = makeEnv({ fetchImpl: async () => new Response(JSON.stringify({ ok: false }), { status: 200, headers: { "content-type": "application/json" } }) });
+  try {
+    const checks = await checkDoctor(env.options);
+    const health = checks.find((check) => check.name === "Gateway health");
+    assert.equal(health.status, "warn");
+    assert.match(health.detail, /no provider token/);
+    assert.equal(doctorExitCode(checks), 0);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("plaintext secrets and a world-readable caller key are flagged", async () => {
+  const env = makeEnv({ plainSecret: true, callerMode: 0o644 });
+  try {
+    const checks = await checkDoctor(env.options);
+    const secrets = checks.find((check) => check.name === ".env secret storage");
+    assert.equal(secrets.status, "warn");
+    assert.match(secrets.detail, /OPENCODE_GO_TOKEN stored in plaintext/);
+    const caller = checks.find((check) => check.name === "Caller key file");
+    if (process.platform !== "win32") {
+      assert.equal(caller.status, "warn");
+      assert.match(caller.detail, /world-readable/);
+    }
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("a config.toml routed elsewhere is flagged", async () => {
+  const env = makeEnv({ keyedRoute: false });
+  try {
+    const checks = await checkDoctor(env.options);
+    const route = checks.find((check) => check.name === "Codex route");
+    assert.equal(route.status, "warn");
+    assert.match(route.detail, /not this gateway's keyed URL/);
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("a missing state dir fails the check", async () => {
+  const env = makeEnv();
+  const options = { ...env.options, stateDir: path.join(env.root, "missing-state") };
+  try {
+    const checks = await checkDoctor(options);
+    const state = checks.find((check) => check.name === "State dir");
+    assert.equal(state.status, "fail");
+  } finally {
+    env.cleanup();
+  }
+});
+
+test("no auth.json means the sign-in check warns", async () => {
+  const env = makeEnv({ loggedIn: false });
+  try {
+    const checks = await checkDoctor(env.options);
+    const signIn = checks.find((check) => check.name === "ChatGPT sign-in");
+    assert.equal(signIn.status, "warn");
+  } finally {
+    env.cleanup();
+  }
+});
+
+

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -1198,7 +1198,7 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
         httpStatus: upstream.status,
         upstream: target.provider,
         error: translated.body.error.message.slice(0, 400),
-        requestShape: describeInputShape(normalizedPayload.input),
+        requestShape: describeInputShape(payload.input),
       });
       metrics?.recordResponseTransform?.({
         blocked: { tool_search: 0, web_search: 0 },

--- a/src/gateway.test.mjs
+++ b/src/gateway.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Writable } from "node:stream";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
 import {
   RouteAffinity,
   applyToolPolicy,
@@ -1162,6 +1165,58 @@ test("relayResponses counts the request body bytes as transfer-in", async () => 
     assert.equal(transformOptions[0].streaming, true);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayCompaction reports the failure telemetry when the upstream rejects the summarize call", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const finishes = [];
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-compact-state-"));
+  const previousStateDir = process.env.MODELDOCK_STATE_DIR;
+  process.env.MODELDOCK_STATE_DIR = stateDir;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(
+    JSON.stringify({ error: { message: "invalid_api_key", type: "invalid_request_error" } }),
+    { status: 401, headers: { "content-type": "application/json" } },
+  );
+  try {
+    const result = await relayCompaction(
+      {
+        model: "deepseek-v4-flash",
+        stream: false,
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+          { type: "compaction_trigger" },
+        ],
+      },
+      res,
+      {
+        ...compactServices(),
+        metrics: {
+          begin: () => (telemetry) => finishes.push(telemetry),
+          recordResponseUsage: () => {},
+        },
+      },
+      {},
+      true,
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.httpStatus, 401, "the upstream 401 is reported, not a swallowed 502");
+    assert.equal(finishes.length, 1, "the failure finish fires exactly once");
+    assert.equal(finishes[0].httpStatus, 401);
+    assert.deepEqual(
+      finishes[0].requestShape.itemTypes,
+      { message: 1, compaction_trigger: 1 },
+      "the request shape rides the failure telemetry",
+    );
+    const body = JSON.parse(Buffer.concat(sink.chunks).toString("utf8"));
+    assert.equal(body.error.type, "auth_failed", "the 401 is translated into the auth_failed class");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousStateDir === undefined) delete process.env.MODELDOCK_STATE_DIR;
+    else process.env.MODELDOCK_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
   }
 });
 

--- a/src/vision-eval.mjs
+++ b/src/vision-eval.mjs
@@ -1,7 +1,12 @@
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-export const VISION_ASSETS_DIR = "D:/projects/modeldock/assets/vision";
+// The benchmark images ship inside the repo (assets/vision). The old hardcoded
+// developer path (D:/projects/...) broke every other checkout; default to the
+// repo-relative layout, overridable for mirrored deployments.
+export const VISION_ASSETS_DIR = process.env.MODELDOCK_VISION_ASSETS_DIR
+  || resolve(dirname(fileURLToPath(import.meta.url)), "..", "assets", "vision");
 
 const VERBATIM = " Answer directly and briefly, no explanation.";
 


### PR DESCRIPTION
> **Update 1 (2026-08-09):** rebased onto upstream `main` at `81de474` (v0.2.0). Clean rebase — no conflicts. `npm test`: **268/268** (was 261; baseline grew with upstream's memory-coverage tests).
>
> **Update 2 (2026-08-09):** synced two merge-hygiene fixes:
> - `fix: make vision eval assets dir repo-relative` (a345687) — the `src/vision-eval.mjs` hardcoded-path fix (from #8) now lands on this branch too.
> - `perf: discover tests by glob instead of a hand-maintained list` (2d45934) — `test` script is now `node --test test/*.test.mjs src/*.test.mjs`; no more collisions with #8/#9/#11 on the test-script line. `npm test`: **268/268**.
>
> **Update 3 (2026-08-09):** rebased onto v0.2.1 (`cc0dd74`). Clean rebase, no conflicts. `npm test`: **271/271**.

A 10-point doctor diagnostic, in the spirit of codex-router's doctor.mjs but scoped to what ModelDock can answer. **Stacked on #5 and #6** (branch point: `46cd18f`); the diff shrinks to just this stage's files once those merge.

## What it checks

| # | Check | Detail |
|---|---|---|
| 1 | Node.js | >= 22 (engines requirement) |
| 2 | Gateway health | `/healthz` on the configured port answers ok |
| 3 | ChatGPT sign-in | `~/.codex/auth.json` session — drives native-GPT publishing (stage 1's `hasChatGptLogin`) |
| 4 | OpenCode Go token | env or the codex config backup |
| 5 | .env secret storage | plaintext vs `dpapi:` classification only — **values are never printed** |
| 6 | State dir | exists and writable |
| 7 | Caller-key file | present; POSIX 0600 (Windows reports the ACL) |
| 8 | Codex route | `openai_base_url` in config.toml points at this gateway's keyed `/c//v1` URL |
| 9 | Install integrity | `dist/modeldock.mjs` bundle or `src/server.mjs` source entry |
| 10 | Log & diagnostics | `modeldock.log` size vs the 32 MB rotation cap (stage 2), `compact-failures.jsonl` history |

## Design

- `src/doctor.mjs` returns `{status: ok|warn|fail, name, detail, fix}[]`; every path is injectable (`port`/`stateDir`/`codexHome`/`envFile`/`rootDir`/`fetchImpl`) so the suite runs against a scratch install.
- `scripts/doctor.mjs` CLI: human-readable report, `--json` for machines; **exit code 1 iff any check fails**, warnings never fail the run.
- Read-only: never mints a caller key, never writes state, never starts anything.
- 7 tests: healthy install all-ok; stopped gateway fails; token-less gateway warns (not fail); plaintext secret + world-readable key flagged; misrouted `config.toml` flagged; missing state dir fails; missing sign-in warns.

`npm test`: 271/271 passing.