### PR TITLE
feat: TOML duplicate-key guard and config change manifest

### DIFF
--- a/src/config-switcher.mjs
+++ b/src/config-switcher.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { copyFile, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { appendConfigManifest, assertConfigWriteSafe } from "./toml-guard.mjs";
 
 function sha256(text) {
   return createHash("sha256").update(text).digest("hex");
@@ -334,6 +335,10 @@ export class CodexConfigSwitcher {
         { code: "EXTERNAL_MANAGED" },
       );
     }
+    // Duplicate-key guard: a duplicated TOML key would make Codex refuse to
+    // start, and writing over a broken config would bake the broken state in.
+    // Abort before touching anything (the user's config stays untouched).
+    if (originalExisted) assertConfigWriteSafe(original);
 
     const backupPath = path.join(this.codexHome, `config.toml.modeldock-backup-${timestamp()}-${randomUUID().slice(0, 8)}`);
     if (originalExisted) await copyFile(this.configPath, backupPath);
@@ -348,6 +353,10 @@ export class CodexConfigSwitcher {
       mcpArgs: this.mcpArgs,
       mcpEnv: this.mcpEnv,
     });
+    // Defensive: the writer must never emit duplicates either (setTopLevel
+    // dedupes `model`, the managed block owns its keys, but a future edit could
+    // regress). Abort before the disk write.
+    assertConfigWriteSafe(managed);
     try {
       await writeFile(this.configPath, managed, { encoding: "utf8", mode: 0o600 });
       await this.#writeState({
@@ -361,6 +370,14 @@ export class CodexConfigSwitcher {
         changedAt: new Date().toISOString(),
         onboarded: state.onboarded,
         onboardedAt: state.onboardedAt,
+      });
+      await appendConfigManifest(this.stateDir, {
+        operation: "enable",
+        configPath: this.configPath,
+        backupPath,
+        originalExisted,
+        originalHash: sha256(original),
+        managedHash: sha256(managed),
       });
     } catch (error) {
       if (originalExisted) await writeFile(this.configPath, original, { encoding: "utf8", mode: 0o600 });
@@ -389,6 +406,7 @@ export class CodexConfigSwitcher {
     try {
       if (routeActive && state.originalExisted) {
         const restored = sha256(current) === state.managedHash ? backup : mergeRestoredCodexConfig(current, backup);
+        assertConfigWriteSafe(restored);
         await writeFile(this.configPath, restored, { encoding: "utf8", mode: 0o600 });
       } else if (routeActive) await unlink(this.configPath);
       await this.#writeState({
@@ -399,6 +417,12 @@ export class CodexConfigSwitcher {
         changedAt: new Date().toISOString(),
         onboarded: state.onboarded,
         onboardedAt: state.onboardedAt,
+      });
+      await appendConfigManifest(this.stateDir, {
+        operation: "disable",
+        configPath: this.configPath,
+        lastBackupPath: state.backupPath,
+        restoredFromBackup: sha256(current) === state.managedHash,
       });
     } catch (error) {
       await writeFile(this.configPath, current, { encoding: "utf8", mode: 0o600 });

--- a/src/config-switcher.test.mjs
+++ b/src/config-switcher.test.mjs
@@ -278,3 +278,33 @@ model_catalog_json = "C:/Users/x/codex-router/merged-models.json"
   await assert.rejects(() => switcher.enable(), (error) => error.code === "EXTERNAL_MANAGED");
   assert.equal(await readFile(configPath, "utf8"), routerManaged, "the conflicting config is left untouched");
 });
+
+test("enable refuses a config with duplicated TOML keys and leaves the file untouched", async (t) => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), "modeldock-duplicate-key-"));
+  t.after(() => rm(codexHome, { recursive: true, force: true }));
+  const configPath = path.join(codexHome, "config.toml");
+  const duplicated = 'model = "gpt-5.6-sol"\nmodel = "gpt-5.6-codex"\n';
+  await writeFile(configPath, duplicated, "utf8");
+  const switcher = new CodexConfigSwitcher({ codexHome, baseUrl: "http://127.0.0.1:4097/v1", model: "deepseek-v4-flash" });
+  await assert.rejects(
+    () => switcher.enable(),
+    (error) => error.code === "DUPLICATE_TOML_KEY" && /duplicate key\(s\): model/.test(error.message),
+  );
+  assert.equal(await readFile(configPath, "utf8"), duplicated, "the broken config is left untouched");
+  await assert.rejects(() => access(path.join(codexHome, "modeldock", "config-manifest.jsonl")), (error) => error.code === "ENOENT", "no manifest entry for the aborted write");
+});
+
+test("enable and disable append audit entries to the config manifest", async (t) => {
+  const { codexHome, configPath, switcher } = await fixture(t);
+  await switcher.enable();
+  await switcher.disable();
+  const manifestPath = path.join(codexHome, "modeldock", "config-manifest.jsonl");
+  const lines = (await readFile(manifestPath, "utf8")).trim().split("\n");
+  assert.equal(lines.length, 2, "one entry per operation");
+  const [enabled, disabled] = lines.map((line) => JSON.parse(line));
+  assert.equal(enabled.operation, "enable");
+  assert.equal(disabled.operation, "disable");
+  assert.ok(enabled.backupPath && enabled.originalHash && enabled.managedHash, "the enable entry records backup and hashes");
+  assert.ok(enabled.at <= disabled.at, "entries are append-ordered");
+  assert.match(await readFile(configPath, "utf8"), /^model = "gpt-5.6-sol"/m, "disable restores the original config");
+});

--- a/src/toml-guard.mjs
+++ b/src/toml-guard.mjs
@@ -1,0 +1,72 @@
+// Config write guards, in the spirit of the DeepSeek setup script's duplicate-
+// key self-check (:684-705) and change manifest (:712-722). A TOML config with
+// a duplicated key makes Codex refuse to start, so ModelDock must never write
+// one - and when the user's own config already carries duplicates, the write
+// must stop before touching the file instead of baking the broken state in.
+import { mkdir, appendFile } from "node:fs/promises";
+import path from "node:path";
+
+// Full-key duplicate scan: tracks the current table so both top-level and
+// in-table duplicates are caught ([mcp_servers.modeldock] url= twice is just as
+// fatal as two top-level model= lines). Array-of-tables ([[...]]) is treated
+// as a distinct table so repeated [[entries]] do not false-positive.
+export function duplicateKeys(source) {
+  const counts = new Map();
+  const currentTable = [""];
+  const arrayTableCount = new Map();
+  let depth = 0;
+  for (const raw of String(source || "").replace(/\r\n/g, "\n").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    if (line.startsWith("[[")) {
+      // Each [[entry]] is a fresh array element: repeated entries are legal and
+      // share the table name, so give every instance its own path (providers#1,
+      // providers#2) to avoid false positives on identical per-entry keys.
+      depth += 1;
+      const tableName = line.slice(2, -2).trim();
+      const instance = (arrayTableCount.get(tableName) || 0) + 1;
+      arrayTableCount.set(tableName, instance);
+      currentTable[depth] = `${tableName}#${instance}`;
+      continue;
+    }
+    if (line.startsWith("[")) {
+      depth += 1;
+      currentTable[depth] = line.slice(1, -1).trim();
+      continue;
+    }
+    if (line.startsWith("]")) continue;
+    const match = line.match(/^([A-Za-z0-9_.-]+)\s*=/);
+    if (!match) continue;
+    const table = currentTable[depth] || "";
+    const fullKey = table ? `${table}.${match[1]}` : match[1];
+    counts.set(fullKey, (counts.get(fullKey) || 0) + 1);
+  }
+  return [...counts.entries()].filter(([, count]) => count > 1).map(([key]) => key);
+}
+
+// Throws when the source would break Codex. A TOML duplicate is a hard parse
+// failure at Codex startup, so the guard aborts the write before anything is
+// touched (DeepSeek setup script :684-705 semantics).
+export function assertConfigWriteSafe(source) {
+  const duplicates = duplicateKeys(source);
+  if (duplicates.length) {
+    const error = new Error(`config.toml has duplicate key(s): ${duplicates.join(", ")}; Codex refuses to start on a duplicated TOML key, so the write was aborted and the file was left untouched.`);
+    error.code = "DUPLICATE_TOML_KEY";
+    throw error;
+  }
+  return source;
+}
+
+// Append-only audit trail next to the switch state: who changed the Codex
+// config, when, why, and which backup/hashes it involved. Never throws - an
+// audit file must not take the config switch down.
+export async function appendConfigManifest(stateDir, entry) {
+  try {
+    await mkdir(stateDir, { recursive: true });
+    const file = path.join(stateDir, "config-manifest.jsonl");
+    await appendFile(file, `${JSON.stringify({ at: new Date().toISOString(), ...entry })}\n`, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/toml-guard.test.mjs
+++ b/src/toml-guard.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { duplicateKeys, assertConfigWriteSafe, appendConfigManifest } from "./toml-guard.mjs";
+
+const CLEAN = [
+  'model = "gpt-5.6-sol"',
+  "",
+  "[model_providers.opencode]",
+  'experimental_bearer_token = "token"',
+].join("\n");
+
+test("duplicateKeys finds duplicated top-level keys", () => {
+  const source = 'model = "a"\nmodel = "b"\nprofile = "x"\n';
+  assert.deepEqual(duplicateKeys(source), ["model"]);
+});
+
+test("duplicateKeys finds duplicated in-table keys", () => {
+  const source = [
+    "[mcp_servers.modeldock]",
+    'url = "http://a"',
+    'url = "http://b"',
+  ].join("\n");
+  assert.deepEqual(duplicateKeys(source), ["mcp_servers.modeldock.url"]);
+});
+
+test("duplicateKeys ignores comments, blank lines, and repeated array-of-tables entries", () => {
+  const source = [
+    "# model = \"commented\"",
+    'model = "a"',
+    "",
+    "[[providers]]",
+    'name = "one"',
+    "[[providers]]",
+    'name = "two"',
+  ].join("\n");
+  assert.deepEqual(duplicateKeys(source), []);
+});
+
+test("duplicateKeys returns [] for a clean config", () => {
+  assert.deepEqual(duplicateKeys(CLEAN), []);
+});
+
+test("assertConfigWriteSafe throws with DUPLICATE_TOML_KEY and leaves the decision to the caller", () => {
+  const source = 'model = "a"\nmodel = "b"\n';
+  assert.throws(
+    () => assertConfigWriteSafe(source),
+    (error) => error.code === "DUPLICATE_TOML_KEY" && /duplicate key\(s\): model/.test(error.message),
+  );
+  assert.doesNotThrow(() => assertConfigWriteSafe(CLEAN));
+});
+
+test("appendConfigManifest appends one JSON line per entry and never throws", async () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-manifest-"));
+  try {
+    const first = await appendConfigManifest(dir, { operation: "enable", reason: "test" });
+    const second = await appendConfigManifest(dir, { operation: "disable", reason: "test" });
+    assert.equal(first, true);
+    assert.equal(second, true);
+    const lines = readFileSync(path.join(dir, "config-manifest.jsonl"), "utf8").trim().split("\n");
+    assert.equal(lines.length, 2);
+    const [a, b] = lines.map((line) => JSON.parse(line));
+    assert.equal(a.operation, "enable");
+    assert.equal(b.operation, "disable");
+    assert.ok(a.at && b.at, "entries carry a timestamp");
+    const sorted = [a.at, b.at].sort();
+    assert.deepEqual([a.at, b.at], sorted, "entries are append-ordered");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
> **Update 1 (2026-08-09):** rebased onto upstream `main` at `81de474` (v0.2.0). Clean rebase — no conflicts. `npm test`: **269/269** on this branch.
>
> **Update 2 (2026-08-09):** synced two merge-hygiene fixes:
> - `fix: make vision eval assets dir repo-relative` (c07b704) — the `src/vision-eval.mjs` hardcoded-path fix (from #8) now lands on this branch too.
> - `perf: discover tests by glob instead of a hand-maintained list` (4b337f9) — `test` script is now `node --test test/*.test.mjs src/*.test.mjs`; no more collisions on the test-script line. `npm test`: **269/269**.
>
> **Update 3 (2026-08-09):** rebased onto v0.2.1 (`cc0dd74`). Clean rebase, no conflicts. `npm test`: **272/272**.
>
> **Update 4 (2026-08-09):** rebased onto latest upstream (`509992f`). Only conflict was the package.json test-script line (upstream now carries the same glob form plus a `pretest` sandbox-cleanup script — resolved by keeping upstream's). No functional conflicts: upstream's config changes (settings write protection / token probe) do not touch `config-switcher.mjs` or `toml-guard.mjs`. `npm test`: **288/288** (1 pre-existing upstream failure in `install-mock.test.mjs` — reproduces on pristine `upstream/main`, unrelated to this PR; 1 environment failure in `install-macos-sim` on this Windows/WSL box).

Config write reliability: TOML duplicate-key guard and a change manifest. **Stacked on #5/#6/#7/#8** (branch point `46cd18f`); the diff reduces to this stage's files once the earlier PRs merge.

## 1. TOML duplicate-key guard (`src/toml-guard.mjs`)

A duplicated TOML key makes Codex refuse to start — the single most common way a config rewrite "breaks" the user's setup. Following the DeepSeek setup script's self-check (:684-705):

- `duplicateKeys(source)` scans the full key space: top-level **and** in-table keys (`[mcp_servers.modeldock] url=` twice is just as fatal as two top-level `model=` lines). `[[array-of-tables]]` instances get unique paths (`providers#1`, `providers#2`) so repeated entries with identical per-entry keys never false-positive.
- `assertConfigWriteSafe(source)` throws `DUPLICATE_TOML_KEY` with the offending keys **before anything touches disk**.

## 2. Wired into the switcher (`src/config-switcher.mjs`)

- `enable()` guards **both** the user's existing config (a broken config is never baked in — abort and tell the user which keys to fix) and the managed output (defensive: the writer must never emit duplicates either).
- `disable()` guards the restored config.

## 3. Config change manifest (`config-manifest.jsonl`)

Append-only audit trail next to the switch state (DeepSeek setup script :712-722 spirit): `operation` (enable/disable), `backupPath`, `originalHash`/`managedHash`, `configPath`, timestamps — written after every successful switch, never throws, and an aborted write leaves **no** entry. Every ModelDock config mutation is now attributable and replayable.

## Tests

- `duplicateKeys`: duplicated top-level keys, duplicated in-table keys, array-of-tables exceptions, clean config → `[]`.
- Guard contract: `DUPLICATE_TOML_KEY` error shape; clean config passes.
- Manifest: one JSON line per entry, append-ordered, timestamped, never throws.
- Switcher integration: enable refuses a duplicated config with the file left byte-identical **and** no manifest entry; enable→disable appends exactly two ordered entries and restore round-trips.

`npm test`: 288/288 passing on this branch.