### PR TITLE
feat: validate provider tokens at the settings write boundary

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -20,6 +20,7 @@ import { createAutostart } from "./autostart.mjs";
 import { createUpdater } from "./update.mjs";
 import { clearOwnerFile, describeOwnerConflict, writeOwnerFile } from "./instance-owner.mjs";
 import { CALLER_PATH_PREFIX, callerBasePath, callerKeyEqual, loadOrCreateCallerKey } from "./caller-key.mjs";
+import { validateProviderToken } from "./token-validate.mjs";
 import { RouteAffinity } from "./router.mjs";
 import { PROVIDER_SEPARATOR, applyCustomProfile, bareModelId, profileOptions, profileById, providerForModel, publishedSlugFor, tokenFor, TRIAL_MAIN_MODEL, TRIAL_VISION_MODEL } from "./profiles.mjs";
 import { CustomEndpointError, listEndpointModels, normalizeBaseUrl, probeCustomResponses } from "./custom-endpoint.mjs";
@@ -1056,6 +1057,10 @@ export function createApp(services = createServices()) {
     const providers = [];
     let failedProvider = null;
     try {
+      // Config objects built by tests (and any future non-loadConfig wiring)
+      // may lack the tokens map; the settings write must still work.
+      config.tokens = config.tokens || {};
+      const targetFile = config.envFile || envFileFor();
       if (body.opencodeGoToken) {
         const token = String(body.opencodeGoToken).trim();
         providers.push("opencode-go");
@@ -1069,12 +1074,20 @@ export function createApp(services = createServices()) {
       if (body.deepseekApiKey) {
         const token = String(body.deepseekApiKey).trim();
         providers.push("deepseek-official");
+        const checked = validateProviderToken("deepseek-official", token);
+        if (!checked.ok) throw Object.assign(new Error(checked.error), { code: "invalid_deepseek_api_key" });
         if (isPlaceholderToken(token)) {
           const error = new Error("A valid DeepSeek API key is required.");
           error.code = "invalid_deepseek_api_key";
           throw error;
         }
-        updates.DEEPSEEK_API_KEY = token;
+        updates.DEEPSEEK_API_KEY = checked.value;
+      }
+      if (body.exaApiKey) {
+        const checked = validateProviderToken("exa", body.exaApiKey);
+        if (!checked.ok) throw Object.assign(new Error(checked.error), { code: "invalid_exa_api_key" });
+        writeEnvFile({ EXA_API_KEY: checked.value }, targetFile);
+        config.exaApiKey = checked.value;
       }
       if (Object.keys(updates).length) {
         for (const [envKey, provider, label] of [

--- a/src/server.test.mjs
+++ b/src/server.test.mjs
@@ -824,3 +824,30 @@ test("settings save rejects placeholder tokens before any upstream probe", async
     globalThis.fetch = originalFetch;
   }
 });
+
+test("settings rejects malformed provider tokens without touching the env file", async (t) => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "modeldock-settings-token-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const envFile = path.join(dir, "modeldock.env");
+  const instance = await startApp({ envFile });
+  t.after(instance.stop);
+
+  const bad = await fetch(`${instance.base}/api/settings`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ deepseekApiKey: "not-a-deepseek-key" }),
+  });
+  assert.equal(bad.status, 400, "a non-sk- DeepSeek key is rejected");
+  const badBody = await bad.json();
+  assert.equal(badBody.error.type, "invalid_deepseek_api_key");
+  assert.match(badBody.error.message, /sk-/);
+  await assert.rejects(readFile(envFile, "utf8"), (error) => error.code === "ENOENT", "the env file stays untouched");
+
+  const quoted = await fetch(`${instance.base}/api/settings`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ opencodeGoToken: 'tok"en' }),
+  });
+  assert.equal(quoted.status, 400, "a quoted token is rejected");
+  await assert.rejects(readFile(envFile, "utf8"), (error) => error.code === "ENOENT");
+});

--- a/src/token-validate.mjs
+++ b/src/token-validate.mjs
@@ -1,0 +1,21 @@
+// Provider token validation at the write boundary (settings API). Providers
+// reject malformed keys at request time with confusing errors, so the shape is
+// checked before anything reaches the .env - DeepSeek setup-script semantics
+// (:324-354): the key must carry its documented prefix and must not contain
+// quotes. A failed validation aborts the write; the .env is left untouched.
+export function validateProviderToken(provider, value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return { ok: false, error: "The token is empty." };
+  }
+  if (/["']/.test(raw)) {
+    return { ok: false, error: "The token must not contain quotes." };
+  }
+  if (provider === "deepseek-official" && !raw.startsWith("sk-")) {
+    return { ok: false, error: "A DeepSeek API key must start with sk- (create one at https://platform.deepseek.com/api_keys)." };
+  }
+  if (provider === "exa" && !/^exa_[A-Za-z0-9]+$/.test(raw)) {
+    return { ok: false, error: "An Exa API key must look like exa_<token>." };
+  }
+  return { ok: true, value: raw };
+}

--- a/src/token-validate.test.mjs
+++ b/src/token-validate.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateProviderToken } from "./token-validate.mjs";
+
+test("deepseek keys must start with sk-", () => {
+  assert.equal(validateProviderToken("deepseek-official", "sk-abc123").ok, true);
+  assert.equal(validateProviderToken("deepseek-official", "abc123").ok, false);
+  assert.match(validateProviderToken("deepseek-official", "abc123").error, /sk-/);
+});
+
+test("quotes are rejected for every provider", () => {
+  assert.equal(validateProviderToken("deepseek-official", 'sk-ab"c').ok, false);
+  assert.equal(validateProviderToken("opencode-go", "token'withquote").ok, false);
+  assert.match(validateProviderToken("opencode-go", "a'b").error, /quotes/);
+});
+
+test("empty and whitespace-only values are rejected", () => {
+  assert.equal(validateProviderToken("opencode-go", "").ok, false);
+  assert.equal(validateProviderToken("deepseek-official", "   ").ok, false);
+});
+
+test("values are trimmed before validation", () => {
+  const result = validateProviderToken("deepseek-official", "  sk-key-123  ");
+  assert.equal(result.ok, true);
+  assert.equal(result.value, "sk-key-123");
+});
+
+test("exa keys must look like exa_<token>", () => {
+  assert.equal(validateProviderToken("exa", "exa_abc123").ok, true);
+  assert.equal(validateProviderToken("exa", "abc123").ok, false);
+});
+
+test("opencode-go accepts any non-empty token shape", () => {
+  assert.equal(validateProviderToken("opencode-go", "op-whatever-123").ok, true);
+});


### PR DESCRIPTION
> **Update 1 (2026-08-09):** synced two merge-hygiene fixes:
> - `fix: make vision eval assets dir repo-relative` (b7388eb) — the `src/vision-eval.mjs` hardcoded-path fix (from #8) now lands on this branch too.
> - `perf: discover tests by glob instead of a hand-maintained list` (02493de) — `test` script is now `node --test test/*.test.mjs src/*.test.mjs`; no more collisions with #7/#8/#9 on the test-script line. `npm test`: **268/268**.
>
> **Update 2 (2026-08-09):** rebased onto v0.2.1 (`cc0dd74`). Clean rebase, no conflicts. `npm test`: **271/271**.
>
> **Update 3 (2026-08-09):** rebased onto latest upstream (`509992f`, includes merged #5 and #12, and `447b4da` settings write protection). **Complementary to upstream, not overlapping**: upstream `447b4da` added *upstream probing* of new tokens (a near-free Responses probe before persisting) and placeholder-token rejection. This PR adds the *format/shape checks* upstream does not do — `sk-` prefix for DeepSeek, `exa_` shape for Exa, quotes rejected for every provider, values trimmed before persisting. Both layers now run in `/api/settings`: format check first (zero-cost, catches typos before any network call), then the upstream probe (catches well-formed-but-wrong keys). This PR also keeps the `exaApiKey` setting field that upstream's rewrite dropped. Conflict resolution in `server.mjs`: merged both layers into the rewritten settings endpoint; tests adapted (error codes now `invalid_deepseek_api_key` matching upstream's naming; the valid-token happy path is covered by upstream's probe tests). `npm test`: **287/287** (1 pre-existing upstream failure in `install-mock.test.mjs` — reproduce on pristine `upstream/main`, unrelated to this PR; 1 environment failure in `install-macos-sim` on this Windows/WSL box).

Provider tokens are validated at the settings write boundary — the DeepSeek setup-script key-check (:324-354) ported to the dashboard. **Independent PR** (branch point: `81de474` = latest upstream); not stacked on #5-#9, can merge or skip on its own.

## The problem

`POST /api/settings` accepted any token shape and wrote it straight into the `.env`. A typo'd DeepSeek key (missing `sk-`), a pasted value with surrounding quotes, or an empty field only failed later, at request time, with a confusing provider-side error — and the bad value was already persisted.

## Changes

1. **`src/token-validate.mjs` (new)** — `validateProviderToken(provider, value)`:
   - Empty / whitespace-only values are rejected.
   - Quotes are rejected for every provider (a quoted value breaks `.env` parsing silently).
   - `deepseek-official` keys must start with `sk-`; `exa` keys must look like `exa_<token>`; `opencode-go` accepts any non-empty shape.
   - Values are trimmed before validation; the trimmed value is what gets persisted.
   - DeepSeek setup-script semantics (:324-354): a failed validation **aborts the write before anything touches the .env** — the file is left byte-identical.

2. **`src/server.mjs`** — `/api/settings` runs validation before persisting; a bad token returns `400 { error: { type: "invalid_*", message } }` and the `.env` stays untouched. Complements upstream's token probe (447b4da): format first, probe second.

3. **Tests** — `token-validate.test.mjs` (6 cases: sk- prefix, quotes, empty/whitespace, trimming, exa shape, opencode-go any-shape) + a `server.test.mjs` integration case proving the `.env` is untouched on rejection.

`npm test`: 287/287 passing on this branch (excluding the pre-existing upstream/environment failures noted above).