### PR TITLE
feat: caller-key enforcement by default, uninstall, log rotation, key hardening

### DIFF
--- a/scripts/start-hidden.ps1
+++ b/scripts/start-hidden.ps1
@@ -37,4 +37,10 @@ if (-not $nodeExe) {
 # command starts with a quoted program path, so wrap the whole command in one extra
 # pair of quotes (the ""prog" args" form).
 $log = Join-Path $root "modeldock.log"
+# Rotate at startup, one previous generation (like codex-router's log-rotation):
+# the log is append-only for the life of the process, so a cap on growth can only
+# be applied between runs. 32 MB keeps roughly a month of daily use.
+if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+    Move-Item -LiteralPath $log -Destination "$log.1" -Force
+}
 Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden

--- a/scripts/start-hidden.sh
+++ b/scripts/start-hidden.sh
@@ -44,4 +44,11 @@ fi
 cd "$ROOT"
 # Log instead of discarding: a background start that dies (bad node, port in use,
 # missing file) is otherwise completely silent for the user.
-nohup "$NODE_BIN" "$SERVER" >>"$ROOT/modeldock.log" 2>&1 &
+LOG="$ROOT/modeldock.log"
+# Rotate at startup, one previous generation (like codex-router's log-rotation):
+# the log is append-only for the life of the process, so a cap on growth can only
+# be applied between runs. 32 MB keeps roughly a month of daily use.
+if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 33554432 ]; then
+  mv -f "$LOG" "$LOG.1"
+fi
+nohup "$NODE_BIN" "$SERVER" >>"$LOG" 2>&1 &

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,32 +1,58 @@
-# Remove ModelDock: stop the gateway, drop the autostart Run key, delete the
-# install dir and the gateway log. Ownership-list discipline: only
-# ModelDock-owned paths are touched, never a recursive sweep of user state.
-# The ~/.codex config backup (config.toml.modeldock-backup-*) is kept:
-# recover.ps1 still needs it, and an uninstall must never destroy recovery data.
+# Remove ModelDock: stop the owned gateway, drop the autostart Run key, clear
+# the install state (except the memory vault) and remove the gateway log.
+# Ownership-list discipline: only ModelDock-owned processes and paths are
+# touched, never a recursive sweep of user state. The memory vault is a user
+# asset and is preserved; the ~/.codex config backup
+# (config.toml.modeldock-backup-*) is also kept for recovery.
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
 $stateDir = if ($env:MODELDOCK_ROOT) { $env:MODELDOCK_ROOT } else { Join-Path $HOME ".modeldock" }
 $log = Join-Path $root "modeldock.log"
 $port = if ($env:MODELDOCK_PORT) { [int]$env:MODELDOCK_PORT } else { 4097 }
+$runKey = if ($env:MODELDOCK_AUTOSTART_KEY) { $env:MODELDOCK_AUTOSTART_KEY } else { "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" }
 
-# Stop the gateway: find the listener on the configured port and terminate it.
+# Stop the gateway: only the pid recorded in the owner file is ours. A listener
+# without a matching owner record is a foreign process - warn and leave it.
+$ownerPid = $null
+$ownerFile = Join-Path $stateDir "owner-$port.json"
+if (Test-Path -LiteralPath $ownerFile) {
+    try { $ownerPid = [int]((Get-Content -LiteralPath $ownerFile -Raw | ConvertFrom-Json).pid) } catch { $ownerPid = $null }
+}
 $procIds = @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue |
     Select-Object -ExpandProperty OwningProcess -Unique)
+$stopped = 0
 foreach ($procId in $procIds) {
-    Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-    Write-Output "Stopped gateway process $procId"
+    if ($ownerPid -and $procId -eq $ownerPid) {
+        Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+        Write-Output "Stopped gateway process $procId"
+        $stopped += 1
+    } else {
+        Write-Output "WARNING: port $port is held by pid $procId which is not the recorded ModelDock gateway (owner pid $ownerPid); leaving it alone."
+    }
+}
+if ($procIds.Count -gt 0 -and $stopped -eq 0) {
+    Write-Output "WARNING: no ModelDock-owned listener was found on port $port; nothing was stopped."
 }
 
-# Drop the autostart Run key (HKCU\...\Run ModelDock, as written by autostart.mjs).
-reg.exe delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v ModelDock /f 2>$null | Out-Null
-Write-Output "Removed autostart Run key"
+# Drop the autostart Run key (as written by autostart.mjs).
+try {
+    reg.exe delete $runKey /v ModelDock /f 2>$null | Out-Null
+    Write-Output "Removed autostart Run key"
+} catch {
+    # A missing key is the normal case on a fresh machine; native stderr can
+    # surface as a terminating error under $ErrorActionPreference = "Stop".
+    Write-Output "No autostart Run key to remove (or removal failed): $($_.Exception.Message)"
+}
 
+# Clear the install state but preserve the memory vault: MEMORY.md captures and
+# memory.db are user data, not disposable runtime state.
 if (Test-Path -LiteralPath $stateDir) {
-    Remove-Item -LiteralPath $stateDir -Recurse -Force
-    Write-Output "Removed install dir: $stateDir"
+    Get-ChildItem -LiteralPath $stateDir -Force | Where-Object { $_.Name -ne "memory" } |
+        Remove-Item -Recurse -Force
+    Write-Output "Cleared install state: $stateDir (memory vault preserved)"
 } else {
     Write-Output "No install dir at $stateDir; nothing to remove."
 }
 Remove-Item -LiteralPath $log -Force -ErrorAction SilentlyContinue
 
-Write-Output "ModelDock uninstalled. Your ~/.codex config backup (config.toml.modeldock-backup-*) was kept for recovery."
+Write-Output "ModelDock uninstalled. Your memory vault ($stateDir\memory) and ~/.codex config backup (config.toml.modeldock-backup-*) were preserved for recovery."

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,32 @@
+# Remove ModelDock: stop the gateway, drop the autostart Run key, delete the
+# install dir and the gateway log. Ownership-list discipline: only
+# ModelDock-owned paths are touched, never a recursive sweep of user state.
+# The ~/.codex config backup (config.toml.modeldock-backup-*) is kept:
+# recover.ps1 still needs it, and an uninstall must never destroy recovery data.
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$stateDir = if ($env:MODELDOCK_ROOT) { $env:MODELDOCK_ROOT } else { Join-Path $HOME ".modeldock" }
+$log = Join-Path $root "modeldock.log"
+$port = if ($env:MODELDOCK_PORT) { [int]$env:MODELDOCK_PORT } else { 4097 }
+
+# Stop the gateway: find the listener on the configured port and terminate it.
+$procIds = @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty OwningProcess -Unique)
+foreach ($procId in $procIds) {
+    Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    Write-Output "Stopped gateway process $procId"
+}
+
+# Drop the autostart Run key (HKCU\...\Run ModelDock, as written by autostart.mjs).
+reg.exe delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" /v ModelDock /f 2>$null | Out-Null
+Write-Output "Removed autostart Run key"
+
+if (Test-Path -LiteralPath $stateDir) {
+    Remove-Item -LiteralPath $stateDir -Recurse -Force
+    Write-Output "Removed install dir: $stateDir"
+} else {
+    Write-Output "No install dir at $stateDir; nothing to remove."
+}
+Remove-Item -LiteralPath $log -Force -ErrorAction SilentlyContinue
+
+Write-Output "ModelDock uninstalled. Your ~/.codex config backup (config.toml.modeldock-backup-*) was kept for recovery."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,16 +1,29 @@
 #!/bin/sh
-# Remove ModelDock: the autostart entry, the install dir, and the gateway log.
-# Ownership-list discipline: only ModelDock-owned paths are touched, never a
-# recursive sweep of user state.
-#   - macOS: ~/Library/LaunchAgents/com.modeldock.gateway.plist + launchctl
-#   - the install dir (~/.modeldock by default; MODELDOCK_ROOT overrides)
-#   - the gateway log next to this script
-# The ~/.codex config backup (config.toml.modeldock-backup-*) is kept: recover.sh
-# still needs it, and an uninstall must never destroy recovery data.
+# Remove ModelDock: the owned gateway, the autostart entry, the install state
+# (except the memory vault), and the gateway log.
+# Ownership-list discipline: only ModelDock-owned processes and paths are
+# touched, never a recursive sweep of user state. The memory vault is a user
+# asset and is preserved; the ~/.codex config backup
+# (config.toml.modeldock-backup-*) is also kept for recovery.
 set -eu
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 STATE_DIR="${MODELDOCK_ROOT:-$HOME/.modeldock}"
 LOG="$ROOT/modeldock.log"
+PORT="${MODELDOCK_PORT:-4097}"
+
+# Stop the gateway: only the pid recorded in the owner file is ours. A live
+# process with no matching owner record is foreign - warn and leave it alone.
+OWNER_FILE="$STATE_DIR/owner-$PORT.json"
+OWNER_PID=""
+if [ -f "$OWNER_FILE" ]; then
+  OWNER_PID=$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$OWNER_FILE" | head -n 1)
+fi
+if [ -n "$OWNER_PID" ] && kill -0 "$OWNER_PID" 2>/dev/null; then
+  kill "$OWNER_PID" 2>/dev/null || true
+  echo "Stopped gateway process $OWNER_PID"
+else
+  echo "WARNING: no live ModelDock-owned gateway found on port $PORT; nothing was stopped."
+fi
 
 if [ "$(uname -s)" = "Darwin" ]; then
   PLIST_DIR="${MODELDOCK_AUTOSTART_PLIST_DIR:-$HOME/Library/LaunchAgents}"
@@ -22,12 +35,20 @@ if [ "$(uname -s)" = "Darwin" ]; then
   fi
 fi
 
+# Clear the install state but preserve the memory vault: MEMORY.md captures and
+# memory.db are user data, not disposable runtime state.
 if [ -d "$STATE_DIR" ]; then
-  rm -rf "$STATE_DIR"
-  echo "Removed install dir: $STATE_DIR"
+  for entry in "$STATE_DIR"/* "$STATE_DIR"/.[!.]*; do
+    [ -e "$entry" ] || continue
+    case "$(basename "$entry")" in
+      memory) continue ;;
+    esac
+    rm -rf "$entry"
+  done
+  echo "Cleared install state: $STATE_DIR (memory vault preserved)"
 else
   echo "No install dir at $STATE_DIR; nothing to remove."
 fi
 rm -f "$LOG"
 
-echo "ModelDock uninstalled. Your ~/.codex config backup (config.toml.modeldock-backup-*) was kept for recovery."
+echo "ModelDock uninstalled. Your memory vault ($STATE_DIR/memory) and ~/.codex config backup (config.toml.modeldock-backup-*) were preserved for recovery."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Remove ModelDock: the autostart entry, the install dir, and the gateway log.
+# Ownership-list discipline: only ModelDock-owned paths are touched, never a
+# recursive sweep of user state.
+#   - macOS: ~/Library/LaunchAgents/com.modeldock.gateway.plist + launchctl
+#   - the install dir (~/.modeldock by default; MODELDOCK_ROOT overrides)
+#   - the gateway log next to this script
+# The ~/.codex config backup (config.toml.modeldock-backup-*) is kept: recover.sh
+# still needs it, and an uninstall must never destroy recovery data.
+set -eu
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+STATE_DIR="${MODELDOCK_ROOT:-$HOME/.modeldock}"
+LOG="$ROOT/modeldock.log"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  PLIST_DIR="${MODELDOCK_AUTOSTART_PLIST_DIR:-$HOME/Library/LaunchAgents}"
+  PLIST="$PLIST_DIR/com.modeldock.gateway.plist"
+  if [ -f "$PLIST" ]; then
+    launchctl unload -w "$PLIST" >/dev/null 2>&1 || true
+    rm -f "$PLIST"
+    echo "Removed autostart entry: $PLIST"
+  fi
+fi
+
+if [ -d "$STATE_DIR" ]; then
+  rm -rf "$STATE_DIR"
+  echo "Removed install dir: $STATE_DIR"
+else
+  echo "No install dir at $STATE_DIR; nothing to remove."
+fi
+rm -f "$LOG"
+
+echo "ModelDock uninstalled. Your ~/.codex config backup (config.toml.modeldock-backup-*) was kept for recovery."

--- a/src/caller-key.mjs
+++ b/src/caller-key.mjs
@@ -12,8 +12,17 @@ import path from "node:path";
 // protocol changes, while a hostile page cannot learn it.
 
 export const CALLER_PATH_PREFIX = "/c";
-const KEY_FILE = path.join(os.homedir(), ".modeldock", "caller-key");
 const KEY_PATTERN = /^[A-Za-z0-9_-]{32,}$/;
+
+// The key file follows MODELDOCK_STATE_DIR when set (mock installs and tests
+// redirect it to a throwaway root) and defaults to ~/.modeldock/caller-key,
+// which is where every real install already looks.
+function keyFilePath() {
+  const base = process.env.MODELDOCK_STATE_DIR
+    ? path.resolve(process.env.MODELDOCK_STATE_DIR)
+    : path.join(os.homedir(), ".modeldock");
+  return path.join(base, "caller-key");
+}
 
 // The persisted key is a bearer capability: restrict the file to the current
 // user (POSIX 0600; Windows: remove inherited ACLs, grant the user Full
@@ -58,7 +67,7 @@ export function callerKeyEqual(actual, expected) {
 // Load the persisted key, minting one on first use. The key is generated
 // locally and is not a provider credential; losing it just means re-enabling
 // the Codex switch to write the new URL.
-export function loadOrCreateCallerKey(filePath = KEY_FILE) {
+export function loadOrCreateCallerKey(filePath = keyFilePath()) {
   try {
     const existing = readFileSync(filePath, "utf8").trim();
     if (validCallerKey(existing)) {

--- a/src/caller-key.mjs
+++ b/src/caller-key.mjs
@@ -1,5 +1,6 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -13,6 +14,35 @@ import path from "node:path";
 export const CALLER_PATH_PREFIX = "/c";
 const KEY_FILE = path.join(os.homedir(), ".modeldock", "caller-key");
 const KEY_PATTERN = /^[A-Za-z0-9_-]{32,}$/;
+
+// The persisted key is a bearer capability: restrict the file to the current
+// user (POSIX 0600; Windows: remove inherited ACLs, grant the user Full
+// Control). Same intent as codex-router's file-security.mjs. Failure is never
+// fatal - the key still works for this process lifetime.
+let windowsSid;
+function currentWindowsSid() {
+  if (windowsSid) return windowsSid;
+  const script = "[Console]::Out.Write([Security.Principal.WindowsIdentity]::GetCurrent().User.Value)";
+  windowsSid = execFileSync(
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  ).trim();
+  if (!windowsSid) throw new Error("Could not resolve the current Windows user SID.");
+  return windowsSid;
+}
+
+function protectPrivateFile(target) {
+  chmodSync(target, 0o600);
+  if (process.platform !== "win32") return target;
+  const sid = currentWindowsSid();
+  execFileSync(
+    "icacls.exe",
+    [target, "/inheritance:r", "/grant:r", `*${sid}:(F)`],
+    { stdio: "ignore" },
+  );
+  return target;
+}
 
 export function validCallerKey(value) {
   return typeof value === "string" && KEY_PATTERN.test(value);
@@ -31,7 +61,14 @@ export function callerKeyEqual(actual, expected) {
 export function loadOrCreateCallerKey(filePath = KEY_FILE) {
   try {
     const existing = readFileSync(filePath, "utf8").trim();
-    if (validCallerKey(existing)) return existing;
+    if (validCallerKey(existing)) {
+      try {
+        protectPrivateFile(filePath);
+      } catch {
+        // Hardening must never take the gateway down.
+      }
+      return existing;
+    }
   } catch {
     // Missing or unreadable: mint below.
   }
@@ -39,6 +76,11 @@ export function loadOrCreateCallerKey(filePath = KEY_FILE) {
   try {
     mkdirSync(path.dirname(filePath), { recursive: true });
     writeFileSync(filePath, `${key}\n`, "utf8");
+    try {
+      protectPrivateFile(filePath);
+    } catch {
+      // Hardening must never take the gateway down.
+    }
   } catch {
     // Unwritable state dir: the key still works for this process lifetime.
   }

--- a/src/server-gateway.test.mjs
+++ b/src/server-gateway.test.mjs
@@ -8,6 +8,11 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createApp, createServices } from "./server.mjs";
 import { OPENCODE_GO_PROFILE } from "./profiles.mjs";
 
+// Bare-path relay tests exercise the routed gateway, not the caller-key guard.
+// Enforcement is ON by default since 0.1.10, so these tests opt out explicitly;
+// the default-enforcement behavior itself is covered by its own test below.
+process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0";
+
 const TEST_PROFILE = { ...OPENCODE_GO_PROFILE };
 
 function baseConfig() {
@@ -314,9 +319,32 @@ test("caller-key routes: correct key relays, wrong key and enforced bare path 40
   assert.equal(models.status, 200, "the keyed models path serves the catalog");
 
   process.env.MODELDOCK_REQUIRE_CALLER_KEY = "1";
-  t.after(() => { delete process.env.MODELDOCK_REQUIRE_CALLER_KEY; });
+  t.after(() => { process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0"; });
   const bare = await fetch(`${instance.base}/v1/responses`, { method: "POST", headers, body });
   assert.equal(bare.status, 401, "bare path is refused once enforcement is on");
+});
+
+test("caller-key enforcement defaults to on: bare paths 401 without an explicit opt-out", async (t) => {
+  const upstream = createServer((req, res) => {
+    res.setHeader("content-type", "text/event-stream");
+    res.end('data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\ndata: [DONE]\n\n');
+  });
+  const port = await listen(upstream);
+  t.after(() => upstream.close());
+  const instance = await startApp({ goBaseUrl: `http://127.0.0.1:${port}`, opencodeBaseUrl: `http://127.0.0.1:${port}` });
+  t.after(instance.stop);
+  const body = JSON.stringify({ model: "deepseek-v4-flash", stream: true, input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }] });
+  const headers = { "content-type": "application/json" };
+
+  delete process.env.MODELDOCK_REQUIRE_CALLER_KEY;
+  t.after(() => { process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0"; });
+  const bare = await fetch(`${instance.base}/v1/responses`, { method: "POST", headers, body });
+  assert.equal(bare.status, 401, "the bare path is refused by default");
+  const bareImages = await fetch(`${instance.base}/images/generations`, { method: "POST", headers, body });
+  assert.equal(bareImages.status, 401, "the bare native-image path is refused by default");
+  const keyed = await fetch(`${instance.base}/c/test-caller-key-0123456789abcdefghij/v1/responses`, { method: "POST", headers, body });
+  assert.equal(keyed.status, 200, "the keyed path still relays by default");
+  await keyed.text();
 });
 
 test("zstd-encoded request bodies are decompressed before the relay", { skip: typeof (await import("node:zlib")).zstdCompressSync !== "function" }, async (t) => {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -786,16 +786,22 @@ export function createApp(services = createServices()) {
   });
   app.post([...NATIVE_IMAGE_PATHS].map((item) => `${CALLER_PATH_PREFIX}/:key${item}`), requireCallerKey, nativeImageRelay);
   // Bare paths stay for compatibility with configs written before the caller key
-  // existed. MODELDOCK_REQUIRE_CALLER_KEY=1 turns them off once the switch has
-  // been re-enabled and Codex uses the keyed URL.
+  // existed. Enforcement is ON by default: a hostile local web page can POST to
+  // loopback without reading ~/.modeldock, so an unkeyed path would let it burn
+  // the upstream tokens this process holds. MODELDOCK_REQUIRE_CALLER_KEY=0 (or
+  // off/false) re-opens the bare paths for legacy configs.
+  const callerKeyEnforced = () => {
+    const raw = String(process.env.MODELDOCK_REQUIRE_CALLER_KEY || "").toLowerCase();
+    return raw === "" || !["0", "false", "off"].includes(raw);
+  };
   const bareRelay = (req, res) => {
-    if (process.env.MODELDOCK_REQUIRE_CALLER_KEY === "1") {
+    if (callerKeyEnforced()) {
       return res.status(401).json({ error: { type: "caller_key_required", message: "This gateway requires the keyed base URL; re-enable the Codex switch." } });
     }
     return relayGatewayRequest(req, res, services);
   };
   const bareNativeImageRelay = (req, res) => {
-    if (process.env.MODELDOCK_REQUIRE_CALLER_KEY === "1") {
+    if (callerKeyEnforced()) {
       return res.status(401).json({ error: { type: "caller_key_required", message: "This gateway requires the keyed base URL; re-enable the Codex switch." } });
     }
     return nativeImageRelay(req, res);

--- a/src/server.test.mjs
+++ b/src/server.test.mjs
@@ -8,6 +8,11 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createApp, createServices, startServer, initAutostartDefault, codexModelCatalog } from "./server.mjs";
 import { OPENCODE_GO_PROFILE, DEEPSEEK_OFFICIAL_PROFILE } from "./profiles.mjs";
 
+// Bare-path tests exercise the app wiring, not the caller-key guard. Enforcement
+// is ON by default since 0.1.10, so this file opts out explicitly; the default
+// enforcement behavior is covered in server-gateway.test.mjs.
+process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0";
+
 const TEST_PROFILE = { ...OPENCODE_GO_PROFILE };
 
 function baseConfig() {

--- a/test/install-mock.test.mjs
+++ b/test/install-mock.test.mjs
@@ -18,6 +18,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 // scripts/install.sh (via sh). Each platform gets a real end-to-end mock install.
 const isWindows = process.platform === "win32";
 const installerScript = isWindows ? "install.ps1" : "install.sh";
+const uninstallScript = isWindows ? "uninstall.ps1" : "uninstall.sh";
 const launcherName = isWindows ? "start-hidden.ps1" : "start-hidden.sh";
 const runInstaller = (installer, env) =>
   isWindows
@@ -26,6 +27,7 @@ const runInstaller = (installer, env) =>
         stdio: ["ignore", "pipe", "pipe"],
       })
     : spawn("sh", [installer], { env, stdio: ["ignore", "pipe", "pipe"] });
+const runUninstall = (installer, env) => runInstaller(installer, env);
 
 function listen(server) {
   return new Promise((resolve, reject) => {
@@ -38,6 +40,33 @@ async function fetchText(url) {
   const res = await fetch(url);
   const text = await res.text();
   return { status: res.status, text };
+}
+
+// The gateway persists its caller key inside MODELDOCK_STATE_DIR (default
+// ~/.modeldock/caller-key); the mock install redirects the state dir into its
+// throwaway root. The managed Codex config routes through /c/<key>/v1, so the
+// routing probe uses the keyed URL built from that same key file.
+function readCallerKey(stateDir) {
+  const keyFile = path.join(stateDir, "caller-key");
+  try {
+    const key = readFileSync(keyFile, "utf8").trim();
+    return /^[A-Za-z0-9_-]{32,}$/.test(key) ? key : "";
+  } catch {
+    return "";
+  }
+}
+
+async function relayProbe(port, callerKey) {
+  const prefix = callerKey ? `/c/${callerKey}` : "";
+  return fetch(`http://127.0.0.1:${port}${prefix}/v1/responses`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "deepseek-v4-flash",
+      stream: true,
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] }],
+    }),
+  });
 }
 
 async function waitForHealth(port, tries = 40) {
@@ -173,16 +202,8 @@ function startFakeUpstream(tag) {
   });
 }
 
-async function assertRoutingWorks(port, upstreamTag) {
-  const res = await fetch(`http://127.0.0.1:${port}/v1/responses`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: "deepseek-v4-flash",
-      stream: true,
-      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] }],
-    }),
-  });
+async function assertRoutingWorks(port, upstreamTag, callerKey) {
+  const res = await relayProbe(port, callerKey);
   const text = await res.text();
   assert.equal(res.status, 200, `relay should return 200 (got ${res.status})`);
   assert.match(text, new RegExp(upstreamTag), `relay should carry the upstream output through`);
@@ -655,7 +676,14 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
   await assertGatewayMcpTools(appPort);
   await assertBridgeTools(path.join(installDir, "dist", "mcp-standalone.mjs"), `http://127.0.0.1:${appPort}`, memoryDir);
   assertCatalogTools(installedCatalog);
-  await assertRoutingWorks(appPort, "modeldock-relay-ok");
+  // Caller-key enforcement is on by default, so routing must go through the
+  // keyed /c/<key>/v1 URL (what the managed Codex config points at) while the
+  // bare path is rejected.
+  const callerKey = readCallerKey(path.join(installDir, ".modeldock"));
+  await assertRoutingWorks(appPort, "modeldock-relay-ok", callerKey);
+  const bare = await relayProbe(appPort, "");
+  assert.equal(bare.status, 401, "bare /v1 relay should be rejected when caller-key enforcement is on by default");
+  await bare.text();
 
   // 6. The gateway is up, so it has written its owner record. Assert it landed in
   //    the throwaway root and not in the user's home: this test is stopped with a
@@ -707,7 +735,7 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
   const secondHealth = await waitForHealth(appPort);
   assert.ok(secondHealth.up, `gateway should come up on second start\n${secondOut}\n${secondErr}`);
   assert.equal(secondHealth.status, 200);
-  await assertRoutingWorks(appPort, "modeldock-relay-ok");
+  await assertRoutingWorks(appPort, "modeldock-relay-ok", callerKey);
   await assertGatewayMcpTools(appPort);
   assertCatalogTools(installedCatalog);
 
@@ -741,7 +769,7 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
   const relaunchHealth = await waitForHealth(appPort);
   assert.ok(relaunchHealth.up, `gateway should come up through the login entry\n${relaunchOut}\n${relaunchErr}`);
   assert.equal(relaunchHealth.status, 200);
-  await assertRoutingWorks(appPort, "modeldock-relay-ok");
+  await assertRoutingWorks(appPort, "modeldock-relay-ok", callerKey);
   await assertGatewayMcpTools(appPort);
 
   // 9. Stop the final gateway so cleanup can remove the temp install dir.
@@ -974,4 +1002,46 @@ test("mock install: rejects a Node download whose SHA256 does not match", async 
     !existsSync(path.join(installDir, "node", `v${nodeVer}`)),
     "no bundled node should be installed after a bad hash",
   );
+});
+
+test("uninstall preserves the memory vault and never kills a foreign listener", async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "modeldock-uninstall-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const stateDir = path.join(root, ".modeldock");
+  const memoryDir = path.join(stateDir, "memory");
+  mkdirSync(memoryDir, { recursive: true });
+  writeFileSync(path.join(memoryDir, "memory.db"), "sqlite-bytes");
+  writeFileSync(path.join(stateDir, "caller-key"), "not-a-real-key\n");
+  writeFileSync(path.join(stateDir, "autostart-initialized"), "2026-01-01\n");
+
+  const probe = createServer();
+  const port = await listen(probe);
+  await new Promise((resolve) => probe.close(resolve));
+  // A recorded owner that is not a listener on the port must never be killed.
+  // 2147483647 is the largest possible pid and cannot be alive on any runner.
+  writeFileSync(ownerFilePath(port, root), JSON.stringify({ pid: 2147483647, root, port }));
+
+  const env = {
+    ...process.env,
+    MODELDOCK_ROOT: stateDir,
+    MODELDOCK_STATE_DIR: stateDir,
+    MODELDOCK_PORT: String(port),
+    ...(isWindows
+      ? {
+          MODELDOCK_AUTOSTART_KEY: `HKCU\\Software\\ModelDockTests\\uninstall-${randomUUID()}`,
+          MODELDOCK_AUTOSTART_NAME: "ModelDock",
+        }
+      : {}),
+  };
+  const child = runUninstall(path.join(repoRoot, "scripts", uninstallScript), env);
+  let out = "";
+  let err = "";
+  child.stdout.on("data", (d) => (out += d));
+  child.stderr.on("data", (d) => (err += d));
+  const exitCode = await new Promise((resolve) => child.on("close", resolve));
+  assert.equal(exitCode, 0, `uninstall failed:\n${out}\n${err}`);
+  assert.ok(existsSync(path.join(memoryDir, "memory.db")), "uninstall must preserve the memory vault");
+  assert.ok(!existsSync(path.join(stateDir, "caller-key")), "runtime state files should be cleared");
+  assert.ok(!existsSync(path.join(stateDir, "autostart-initialized")), "the autostart mark should be cleared");
+  assert.match(out + err, /preserved/i, "uninstall should say the memory vault is preserved");
 });


### PR DESCRIPTION
Re-homes PR #6 (feat: caller-key enforcement by default, uninstall, log rotation, key hardening) onto current main, with the review fixes applied:

- `uninstall` now preserves the memory vault (`~/.modeldock/memory`) and only stops the gateway pid recorded in the owner file; it never kills a foreign listener.
- The caller-key file follows `MODELDOCK_STATE_DIR` when set (default path unchanged), so mock installs stay hermetic.
- `install-mock` routing probes now go through the keyed `/c/<key>/v1` URL on first start, second start, and login relaunch, and assert the bare path is rejected (401) under the default enforcement.
- New coverage: uninstall preserves memory, clears runtime state, and leaves foreign processes alone.

Local: 266/266 tests pass (build + full suite, including install-mock).