### PR TITLE
feat: 无登录 Codex 桌面端的免登录模型选择器别名 + wizard 接线

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { bareModelId, profileById, TRIAL_MAIN_MODEL, TRIAL_VISION_MODEL } from "./profiles.mjs";
 import { readNativeCatalog } from "./native-catalog.mjs";
+import { buildNativeAliasAssignments } from "./native-alias.mjs";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -60,10 +61,70 @@ export function catalogFor(config) {
   // "see it, can't use it" noise (every request 401s), so subscribers keep the
   // merge and everyone else gets the curated catalog only.
   if (config.nativeMerge === false) {
+    // Login-free picker aliasing: the Codex App filters model_catalog_json
+    // against its native-GPT slug allowlist (codex-router native-alias.mjs:10-13
+    // documents the same mechanism), so without aliases a signed-out user's
+    // picker shows nothing but "Custom". Republish external models under the
+    // captured native slugs (verified live: only native-catalog slugs pass the
+    // allowlist - shape alone is not enough) with the external model's own
+    // display name; routing keeps resolving through the hidden canonical entry.
+    if (config.nativeAlias !== false) {
+      return buildLoginFreeCatalog({ ...catalog, models }, config);
+    }
     return { ...catalog, models: orderCatalogByProvider(models) };
   }
   const merged = mergeNativeCatalog({ ...catalog, models }, config);
   return { ...merged, models: orderCatalogByProvider(merged.models) };
+}
+
+// Login-free catalog builder: the Codex App picker filters model_catalog_json
+// against its native-GPT slug allowlist, so signed-out external models are
+// republished under the captured native slugs (the slots the allowlist admits)
+// with the external model's own display name, description, and reasoning
+// levels. Each aliased model keeps a hidden entry under its canonical slug so
+// routing, doctor checks, and saved configs keep resolving; the returned alias
+// map is written to native-aliases.json and consulted by the gateway before
+// the native leg (see gateway.mjs).
+export function buildLoginFreeCatalog(catalog, config) {
+  const native = readNativeCatalog(config);
+  if (!native?.models?.length) {
+    return { ...catalog, models: orderCatalogByProvider(catalog.models || []), aliases: {} };
+  }
+  const external = (catalog.models || []).filter((entry) => !(entry?.visibility === "hide"));
+  // Prefer the models the user actually selected first, then paid models over
+  // free-tier ones, then catalog priority. Native slots are scarce (the allowlist
+  // only admits the captured GPT slugs), so the picker should show the most
+  // useful models - burning a slot on a free-tier model the user never picked
+  // hides a real one.
+  const mainId = bareModelId(config.mainModel);
+  const visionId = bareModelId(config.visionModel);
+  const ranked = [...external].sort((left, right) => {
+    const score = (entry) => {
+      const id = bareModelId(entry.slug);
+      if (id === mainId) return 0;
+      if (id === visionId) return 1;
+      if (String(entry.slug).endsWith("-free") || /-free$/.test(id)) return 4;
+      return 2;
+    };
+    const s = score(left) - score(right);
+    return s || Number(left.priority ?? 999) - Number(right.priority ?? 999);
+  });
+  const assignments = buildNativeAliasAssignments(native.models, ranked);
+  const aliasedSlugs = new Set(assignments.map(({ model }) => model.slug));
+  const aliases = Object.fromEntries(
+    assignments.map(({ nativeModel, model }) => [nativeModel.slug, model.slug]),
+  );
+  const models = [
+    ...assignments.map(({ nativeModel, model }) => ({
+      ...model,
+      slug: nativeModel.slug,
+      priority: nativeModel.priority,
+    })),
+    ...external.map((model) =>
+      aliasedSlugs.has(model.slug) ? { ...model, visibility: "hide" } : model,
+    ),
+  ];
+  return { ...catalog, models: orderCatalogByProvider(models), aliases };
 }
 
 // The Codex App picker list is the model_catalog_json file when configured, not

--- a/src/catalog.test.mjs
+++ b/src/catalog.test.mjs
@@ -151,7 +151,54 @@ test("catalogFor with nativeMerge=false skips the native GPT merge for non-subsc
     const catalog = catalogFor({ ...configStub(), nativeCatalogFile: file, nativeMerge: false });
     const slugs = catalog.models.map((entry) => entry.slug);
     assert.ok(slugs.includes("deepseek-v4-flash"), "curated Go models stay published");
-    assert.ok(!slugs.includes("gpt-5.6-luna"), "native GPT models are hidden without a subscription (nativeMerge=false)");
+    const nativeIdentity = catalog.models.find((entry) => String(entry.display_name).startsWith("OpenAI -"));
+    assert.ok(!nativeIdentity, "no native GPT identity is published (no 'OpenAI -' entry)");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("catalogFor login-free aliasing republishes external models under native slug slots", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-native-alias-"));
+  const file = path.join(dir, "native-catalog.json");
+  writeFileSync(file, JSON.stringify({
+    captured_with: "0.1.0",
+    models: [
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list", priority: 1 },
+      { slug: "gpt-5.6-luna", display_name: "GPT-5.6-Luna", visibility: "list", priority: 3 },
+      { slug: "codex-auto-review", display_name: "Codex Auto Review", visibility: "hide", priority: 43 },
+    ],
+  }), "utf8");
+  try {
+    const catalog = catalogFor({ ...configStub(), nativeCatalogFile: file, nativeMerge: false });
+    const slugs = catalog.models.map((entry) => entry.slug);
+    assert.ok(slugs.includes("gpt-5.6-sol"), "the first native slot is occupied by an aliased external model");
+    assert.ok(slugs.includes("gpt-5.6-luna"), "the second native slot is occupied by an aliased external model");
+    assert.ok(!slugs.includes("codex-auto-review"), "the reserved auto-review slot is never aliased");
+    const aliased = catalog.models.find((entry) => entry.slug === "gpt-5.6-sol");
+    assert.ok(aliased, "aliased entry exists");
+    assert.match(aliased.display_name, /OpenCode Go/, "the external model's own display name is kept");
+    assert.equal(aliased.visibility, "list", "aliased entries stay picker-visible");
+    const canonical = catalog.models.find((entry) => entry.slug === "deepseek-v4-flash");
+    assert.equal(canonical?.visibility, "hide", "the canonical external slug stays published but hidden for routing");
+    assert.ok(catalog.aliases && catalog.aliases["gpt-5.6-sol"] === "deepseek-v4-flash", "the alias map points the native slot at the external model");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("catalogFor login-free aliasing honors MODELDOCK_NATIVE_ALIAS=0 opt-out", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-native-alias-off-"));
+  const file = path.join(dir, "native-catalog.json");
+  writeFileSync(file, JSON.stringify({
+    captured_with: "0.1.0",
+    models: [{ slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list", priority: 1 }],
+  }), "utf8");
+  try {
+    const catalog = catalogFor({ ...configStub(), nativeCatalogFile: file, nativeMerge: false, nativeAlias: false });
+    const slugs = catalog.models.map((entry) => entry.slug);
+    assert.ok(!slugs.includes("gpt-5.6-sol"), "native slot is not occupied when aliasing is disabled");
+    assert.ok(!catalog.aliases, "no alias map when aliasing is disabled");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/src/config-switcher.mjs
+++ b/src/config-switcher.mjs
@@ -119,7 +119,7 @@ function removeManagedRoute(lines) {
       if (MANAGED_END.test(line)) inSentinel = false;
       continue;
     }
-    if (/^\s*\[model_providers\.modeldock_go\]/.test(line)) {
+    if (/^\s*\[model_providers\.modeldock(?:_go)?\]/.test(line)) {
       skippingProvider = true;
       continue;
     }
@@ -182,29 +182,54 @@ function setTopLevel(lines, key, value) {
   return lines;
 }
 
-// Build the transparent managed config: the built-in openai provider stays, its
-// base URL is redirected to the local gate, and the realtime endpoints point at
-// OpenAI so Codex Voice never dials the loopback. The catalog file keeps naming
-// our models in the App picker (openai/codex#32119 only affects custom providers).
-export function buildManagedCodexConfig(source, { baseUrl, model, catalogFile = "", mcpUrl = "", mcpCommand = "", mcpArgs = [], mcpEnv = {} }) {
+// Build the managed Codex config. Two shapes:
+//  - transparent (default): the built-in openai provider stays, its base URL is
+//    redirected to the local gate, and the realtime endpoints point at OpenAI so
+//    Codex Voice never dials the loopback. For signed-in users who keep native
+//    GPT models beside ours (openai/codex#32119 only affects custom providers).
+//  - login-free: a custom [model_providers.modeldock] table with the keyed URL
+//    and a self-contained bearer token, so signed-out Codex never asks for
+//    ChatGPT credentials. Picker aliases (native-alias) make the models list
+//    visible in this shape.
+export function buildManagedCodexConfig(source, { baseUrl, model, catalogFile = "", mcpUrl = "", mcpCommand = "", mcpArgs = [], mcpEnv = {}, loginFree = false }) {
   const newline = source.includes("\r\n") ? "\r\n" : "\n";
   let lines = removeManagedRoute(source.replace(/\r\n/g, "\n").split("\n"));
   while (lines.length && !lines.at(-1).trim()) lines.pop();
   lines = setTopLevel(lines, "model", model);
+  if (loginFree) lines = setTopLevel(lines, "model_provider", "modeldock");
 
-  const managed = [
-    "# BEGIN modeldock-managed",
-    "# Managed by ModelDock: keeps the built-in openai provider and points it at the local gate.",
-    `openai_base_url = ${tomlString(baseUrl)}`,
-  ];
+  const managed = loginFree
+    ? [
+        "# BEGIN modeldock-managed",
+        "# Managed by ModelDock: login-free custom provider (no ChatGPT sign-in required).",
+      ]
+    : [
+        "# BEGIN modeldock-managed",
+        "# Managed by ModelDock: keeps the built-in openai provider and points it at the local gate.",
+        `openai_base_url = ${tomlString(baseUrl)}`,
+      ];
   if (catalogFile) managed.push(`model_catalog_json = ${tomlString(catalogFile)}`);
-  managed.push(
-    'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
-    'experimental_realtime_ws_base_url = "https://api.openai.com/v1"',
-    "# END modeldock-managed",
-  );
+  if (!loginFree) {
+    managed.push(
+      'experimental_realtime_webrtc_call_base_url = "https://chatgpt.com/backend-api/codex"',
+      'experimental_realtime_ws_base_url = "https://api.openai.com/v1"',
+    );
+  }
+  managed.push("# END modeldock-managed");
   const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
   lines.splice(firstTable < 0 ? lines.length : firstTable, 0, "", ...managed);
+
+  if (loginFree) {
+    lines.push(
+      "",
+      "[model_providers.modeldock]",
+      "# Managed by ModelDock: login-free provider table (signed-out Codex).",
+      `name = ${tomlString("ModelDock (external models)")}`,
+      `base_url = ${tomlString(baseUrl)}`,
+      'wire_api = "responses"',
+      'experimental_bearer_token = "modeldock-placeholder"',
+    );
+  }
 
   if (mcpUrl) {
     lines.push(
@@ -230,7 +255,7 @@ export function buildManagedCodexConfig(source, { baseUrl, model, catalogFile = 
 }
 
 export class CodexConfigSwitcher {
-  constructor({ codexHome, baseUrl, model, catalogFile = "", mcpUrl = "", mcpCommand = "", mcpArgs = [], mcpEnv = {} }) {
+  constructor({ codexHome, baseUrl, model, catalogFile = "", mcpUrl = "", mcpCommand = "", mcpArgs = [], mcpEnv = {}, loginFree = false }) {
     this.codexHome = path.resolve(codexHome || path.join(process.cwd(), ".modeldock-codex-home"));
     this.configPath = path.join(this.codexHome, "config.toml");
     this.stateDir = path.join(this.codexHome, "modeldock");
@@ -242,6 +267,7 @@ export class CodexConfigSwitcher {
     this.mcpCommand = mcpCommand;
     this.mcpArgs = mcpArgs;
     this.mcpEnv = mcpEnv;
+    this.loginFree = loginFree;
   }
 
   async #readState() {
@@ -286,8 +312,8 @@ export class CodexConfigSwitcher {
       onboarded: Boolean(state.onboarded),
       onboardedAt: state.onboardedAt || null,
       targetModel: this.model,
-      targetProvider: "openai",
-      targetMode: "openai_base_url",
+      targetProvider: this.loginFree ? "modeldock" : "openai",
+      targetMode: this.loginFree ? "provider_table" : "openai_base_url",
       needsMigration: Boolean(state.enabled && routeActive && !isNewManaged(current) && isLegacyManaged(current)),
       codexRouterConflict: hasCodexRouterBlock(current),
       stateError: state.stateError || null,
@@ -352,6 +378,7 @@ export class CodexConfigSwitcher {
       mcpCommand: this.mcpCommand,
       mcpArgs: this.mcpArgs,
       mcpEnv: this.mcpEnv,
+      loginFree: this.loginFree,
     });
     // Defensive: the writer must never emit duplicates either (setTopLevel
     // dedupes `model`, the managed block owns its keys, but a future edit could

--- a/src/config-switcher.test.mjs
+++ b/src/config-switcher.test.mjs
@@ -308,3 +308,51 @@ test("enable and disable append audit entries to the config manifest", async (t)
   assert.ok(enabled.at <= disabled.at, "entries are append-ordered");
   assert.match(await readFile(configPath, "utf8"), /^model = "gpt-5.6-sol"/m, "disable restores the original config");
 });
+
+test("login-free managed config writes the provider table instead of openai_base_url", () => {
+  const managed = buildManagedCodexConfig(originalConfig, {
+    baseUrl: "http://127.0.0.1:4097/c/callerkey/v1",
+    model: "deepseek-v4-flash",
+    catalogFile: "C:/Users/x/.modeldock/codex-model-catalog.json",
+    mcpUrl: "http://127.0.0.1:4097/mcp",
+    loginFree: true,
+  });
+  assert.match(managed, /^model_provider = "modeldock"$/m, "login-free sets the custom provider");
+  assert.doesNotMatch(managed, /openai_base_url/, "no transparent redirect in login-free mode");
+  assert.doesNotMatch(managed, /experimental_realtime_/, "no realtime endpoints in login-free mode");
+  assert.match(managed, /^\[model_providers\.modeldock\]$/m, "the provider table exists");
+  assert.match(managed, /base_url = "http:\/\/127\.0\.0\.1:4097\/c\/callerkey\/v1"/);
+  assert.match(managed, /wire_api = "responses"/);
+  assert.match(managed, /experimental_bearer_token = "modeldock-placeholder"/);
+  assert.match(managed, /# BEGIN modeldock-managed/);
+  assert.match(managed, /^model_catalog_json = "C:\/Users\/x\/\.modeldock\/codex-model-catalog\.json"$/m);
+  assert.match(managed, /\[mcp_servers\.modeldock\]/);
+  const table = managed.indexOf("[features]");
+  const provider = managed.indexOf("model_provider");
+  assert.ok(provider < table, "model_provider sits before any [table]");
+});
+
+test("login-free enable writes the provider table and disable restores the original config", async (t) => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), "modeldock-config-switch-loginfree-"));
+  t.after(() => rm(codexHome, { recursive: true, force: true }));
+  const configPath = path.join(codexHome, "config.toml");
+  await writeFile(configPath, originalConfig, "utf8");
+  const switcher = new CodexConfigSwitcher({
+    codexHome,
+    baseUrl: "http://127.0.0.1:4097/c/callerkey/v1",
+    model: "deepseek-v4-flash",
+    loginFree: true,
+  });
+
+  const enabled = await switcher.enable();
+  assert.equal(enabled.targetProvider, "modeldock");
+  assert.equal(enabled.targetMode, "provider_table");
+  const managed = await readFile(configPath, "utf8");
+  assert.match(managed, /^model_provider = "modeldock"$/m);
+  assert.match(managed, /^\[model_providers\.modeldock\]$/m);
+  assert.doesNotMatch(managed, /openai_base_url/);
+
+  await switcher.disable();
+  assert.equal(await readFile(configPath, "utf8"), originalConfig, "disable restores the exact original config");
+  assert.doesNotMatch(await readFile(configPath, "utf8"), /model_providers\.modeldock/, "restore removes the provider table");
+});

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -391,6 +391,20 @@ export function loadConfig() {
     // subscription so the picker never advertises models that 401 on request.
     // Defaults to the signed-in state when the env key is unset (see above).
     nativeMerge,
+    // Login-free picker aliases: when the native GPT merge is off, the Codex
+    // App only surfaces catalog slugs that pass its native-GPT allowlist, so
+    // external models are republished under captured native GPT slugs (each
+    // with the external model's own display name) and a hidden canonical entry
+    // keeps routing resolving. On by default for signed-out users; the wizard
+    // nativeMerge toggle implicitly controls this pair.
+    nativeAlias: !["0", "false", "off"].includes(
+      String(process.env.MODELDOCK_NATIVE_ALIAS || "").toLowerCase(),
+    ),
+    // The alias mapping file (native slug -> external slug), written next to the
+    // catalog whenever login-free aliasing is active.
+    nativeAliasesFile: process.env.MODELDOCK_NATIVE_ALIASES_FILE
+      ? path.resolve(process.env.MODELDOCK_NATIVE_ALIASES_FILE)
+      : "",
     mcpTransport,
     visionTimeoutMs: integer("MODELDOCK_VISION_TIMEOUT_MS", 90_000, { min: 1_000, max: 300_000 }),
     mediaTtlMs: integer("MODELDOCK_MEDIA_TTL_MS", 3_600_000, { min: 60_000 }),
@@ -426,6 +440,13 @@ export function loadConfig() {
     // lives at ~/.modeldock/native-catalog.json by default.
     nativeCatalogFile: process.env.MODELDOCK_NATIVE_CATALOG_FILE
       ? path.resolve(process.env.MODELDOCK_NATIVE_CATALOG_FILE)
+      : "",
+    // Where the gateway publishes the Codex model catalog. Defaults to
+    // ~/.modeldock/codex-model-catalog.json; point MODELDOCK_CODEX_CATALOG_FILE
+    // at the path your Codex config reads via model_catalog_json (e.g. the
+    // DeepSeek-script layout puts it in the codex home as models.json).
+    codexCatalogFile: process.env.MODELDOCK_CODEX_CATALOG_FILE
+      ? path.resolve(process.env.MODELDOCK_CODEX_CATALOG_FILE)
       : "",
     refreshNativeCatalog: !["0", "false", "off"].includes(
       String(process.env.MODELDOCK_REFRESH_NATIVE_CATALOG || "").toLowerCase(),

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -8,6 +8,7 @@ import { recordUsageEvent } from "./usage-events.mjs";
 import { translateUpstreamError, freeEmptyOutputError } from "./error-translation.mjs";
 import { RouteAffinity, routeResponsesRequest } from "./router.mjs";
 import { extractResponseUsage } from "./metrics.mjs";
+import { externalModelForAlias } from "./native-alias.mjs";
 
 // Hosted / special tool types Codex can emit that the Go and DeepSeek upstreams
 // reject. The catalog declarations are the primary control; stripping here is the
@@ -1360,7 +1361,16 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
 export async function relayResponses(payload, res, services, { signal } = {}) {
   const { config, metrics, mediaStore, routeAffinity, knownModels, incomingHeaders } = services;
   const { sessionId, threadId } = sessionIdsFrom(incomingHeaders);
-  const requestedModel = normalizeLegacySlug(typeof payload.model === "string" ? payload.model : "", knownModels);
+  let requestedModel = normalizeLegacySlug(typeof payload.model === "string" ? payload.model : "", knownModels);
+  // Login-free alias: the picker surfaces external models under captured native
+  // slugs, so resolve those back to the canonical external slug before the
+  // native-leg check. An aliased slug must route to its external upstream, not
+  // to the ChatGPT backend.
+  const aliasTarget = externalModelForAlias(requestedModel, services.nativeAliases);
+  if (aliasTarget && aliasTarget !== requestedModel) {
+    requestedModel = aliasTarget;
+    payload = { ...payload, model: aliasTarget };
+  }
   if (requestedModel !== payload.model && requestedModel) payload = { ...payload, model: requestedModel };
   if (isNativeModel(requestedModel, knownModels, services.nativeSlugs)) {
     return relayNativeResponses(payload, res, services, { signal });

--- a/src/gateway.test.mjs
+++ b/src/gateway.test.mjs
@@ -797,6 +797,79 @@ test("relayResponses rejects requests without a configured upstream token", asyn
   assert.match(body, /configuration_error/);
 });
 
+test("relayResponses resolves a native alias slug back to the external model", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const originalFetch = globalThis.fetch;
+  let calledUrl = "";
+  globalThis.fetch = async (url, options) => {
+    calledUrl = String(url);
+    const body = options?.body ? JSON.parse(String(options.body)) : null;
+    return new Response(
+      JSON.stringify({
+        id: "resp_alias",
+        status: "completed",
+        model: body?.model || "gpt-5.6-sol",
+        output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "OK" }] }],
+        usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  try {
+    const result = await relayResponses(
+      { model: "gpt-5.6-sol", input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }] },
+      res,
+      {
+        recordUsage: () => {},
+        config: configStub(),
+        routeAffinity: new RouteAffinity(),
+        knownModels: new Set(["deepseek-v4-flash", "gpt-5.6-sol"]),
+        nativeSlugs: new Set(["gpt-5.6-sol"]),
+        nativeAliases: { "gpt-5.6-sol": "deepseek-v4-flash" },
+        mainModel: "deepseek-v4-flash",
+        visionModel: "gpt-5.6-luna",
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.route.model, "deepseek-v4-flash", "the alias resolves to the external model for routing");
+    assert.match(calledUrl, /opencode\.ai\/zen\/go\/v1\/responses/, "the request reaches the external upstream, not ChatGPT");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayResponses keeps unaliased native slugs on the native leg", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const originalFetch = globalThis.fetch;
+  let calledUrl = "";
+  globalThis.fetch = async (url, options) => {
+    calledUrl = String(url);
+    return new Response("not-json-this-test-only-checks-the-url", { status: 200 });
+  };
+  try {
+    const result = await relayResponses(
+      { model: "gpt-5.6-terra", input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }] },
+      res,
+      {
+        recordUsage: () => {},
+        config: configStub(),
+        routeAffinity: new RouteAffinity(),
+        knownModels: new Set(["deepseek-v4-flash"]),
+        nativeSlugs: new Set(["gpt-5.6-terra"]),
+        nativeAliases: { "gpt-5.6-sol": "deepseek-v4-flash" },
+        mainModel: "deepseek-v4-flash",
+        visionModel: "gpt-5.6-luna",
+      },
+    );
+    assert.match(calledUrl, /chatgpt\.com\/backend-api\/codex/, "an unaliased native slug still goes to the ChatGPT backend");
+    assert.equal(result.route?.reason, "native_passthrough");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("isNativeModel distinguishes catalog slugs from native GPT ids", () => {
   const known = new Set(["deepseek-v4-flash", "gpt-5.6-luna"]);
   assert.equal(isNativeModel("gpt-5.6-sol", known), true);

--- a/src/native-alias.mjs
+++ b/src/native-alias.mjs
@@ -1,0 +1,89 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// The Codex App picker filters model_catalog_json entries against a native GPT
+// slug allowlist (captured from `codex debug models --bundled`): external slugs
+// like "deepseek-v4-flash" never appear in the picker for API-key providers.
+// Same mechanism codex-router documents in native-alias.mjs: "Signed-out Codex
+// surfaces only display models whose slugs pass a server-delivered allowlist of
+// native GPT slugs." To make external models selectable while signed out, the
+// catalog republishes them under those native slugs (each carrying the external
+// model's own display name, description, and reasoning levels) while a hidden
+// canonical entry keeps routing, doctor checks, and saved configs resolving.
+// This module owns the slug mapping and its on-disk alias file.
+
+export function nativeAliasesPath(config) {
+  return (config && config.nativeAliasesFile)
+    || path.join(os.homedir(), ".modeldock", "native-aliases.json");
+}
+
+// Pair external models onto the captured native slug slots. Every captured
+// native slug admits the allowlist - verified live: picker-hidden native slugs
+// (gpt-5.4-mini) pass too, while look-alike shapes (gpt-5.6-fake) do not. The
+// auto-review model is a system slot the App manages itself, so it is kept
+// free. Slots are ordered by native picker priority so the surfaces the App
+// shows first are used first. A missing native capture yields no slots:
+// external models then stay on their canonical slugs (today's behavior for CLI
+// users, who never needed aliases).
+const RESERVED_NATIVE_SLOTS = new Set(["codex-auto-review"]);
+
+export function buildNativeAliasAssignments(nativeModels, externalModels) {
+  const slots = (Array.isArray(nativeModels) ? nativeModels : [])
+    .filter((model) => (
+      typeof model?.slug === "string"
+      && !RESERVED_NATIVE_SLOTS.has(model.slug)
+    ))
+    .sort((left, right) => {
+      const priority = Number(left.priority ?? 999) - Number(right.priority ?? 999);
+      return priority || String(left.slug).localeCompare(String(right.slug));
+    });
+  return (Array.isArray(externalModels) ? externalModels : [])
+    .slice(0, slots.length)
+    .map((model, index) => ({ nativeModel: slots[index], model }));
+}
+
+// The alias file is tiny and rewritten whenever the catalog changes, so it is
+// read fresh on every lookup (an mtime-keyed cache is not worth the staleness
+// risk on Windows coarse timestamps - same lesson codex-router records).
+export function readNativeAliases(config) {
+  const file = nativeAliasesPath(config);
+  if (!existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (parsed?.version !== 1 || !parsed.aliases || typeof parsed.aliases !== "object") {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed.aliases).filter(
+        ([nativeSlug, target]) => typeof nativeSlug === "string" && typeof target === "string",
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function writeNativeAliases(aliases, config) {
+  const file = nativeAliasesPath(config);
+  mkdirSync(path.dirname(file), { recursive: true });
+  const temporary = `${file}.tmp.${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify({ version: 1, aliases }, null, 2)}\n`, "utf8");
+  renameSync(temporary, file);
+}
+
+// Resolve a native-slug alias back to the external model it fronts. The
+// gateway consults this before the native leg so aliased slots keep routing
+// externally; an unaliased native slug falls through to the native backend.
+export function externalModelForAlias(aliasSlug, aliases) {
+  if (typeof aliasSlug !== "string" || !aliasSlug) return undefined;
+  const target = aliases?.[aliasSlug];
+  return typeof target === "string" && target ? target : undefined;
+}
+
+// The native slug a published external model occupies, if any. Used by the
+// config builder so the picker highlights the active model under its alias.
+export function nativeSlugForExternal(externalSlug, aliases) {
+  if (typeof externalSlug !== "string" || !externalSlug) return undefined;
+  return Object.keys(aliases || {}).find((nativeSlug) => aliases[nativeSlug] === externalSlug);
+}

--- a/src/native-alias.test.mjs
+++ b/src/native-alias.test.mjs
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildNativeAliasAssignments,
+  externalModelForAlias,
+  nativeAliasesPath,
+  nativeSlugForExternal,
+  readNativeAliases,
+  writeNativeAliases,
+} from "./native-alias.mjs";
+
+const NATIVE = [
+  { slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list", priority: 1 },
+  { slug: "gpt-5.6-terra", display_name: "GPT-5.6-Terra", visibility: "list", priority: 2 },
+  { slug: "gpt-5.6-luna", display_name: "GPT-5.6-Luna", visibility: "list", priority: 3 },
+  { slug: "gpt-5.5", display_name: "GPT-5.5", visibility: "list", priority: 7 },
+  { slug: "gpt-5.4-mini", display_name: "GPT-5.4-Mini", visibility: "hide", priority: 23 },
+  { slug: "codex-auto-review", display_name: "Codex Auto Review", visibility: "hide", priority: 43 },
+];
+
+const EXTERNAL = [
+  { slug: "deepseek-v4-flash", display_name: "OpenCode Go - DeepSeek V4 Flash", priority: 1 },
+  { slug: "glm-5", display_name: "OpenCode Go - GLM 5", priority: 9 },
+  { slug: "kimi-k3", display_name: "OpenCode Go - Kimi K3", priority: 18 },
+];
+
+test("buildNativeAliasAssignments pairs external models onto native slots in priority order", () => {
+  const assignments = buildNativeAliasAssignments(NATIVE, EXTERNAL);
+  assert.equal(assignments.length, 3, "only as many aliases as external models");
+  assert.equal(assignments[0].nativeModel.slug, "gpt-5.6-sol", "the top native slot goes to the top external model");
+  assert.equal(assignments[0].model.slug, "deepseek-v4-flash");
+  assert.equal(assignments[1].nativeModel.slug, "gpt-5.6-terra");
+  assert.equal(assignments[2].nativeModel.slug, "gpt-5.6-luna");
+});
+
+test("buildNativeAliasAssignments never assigns the reserved auto-review slot", () => {
+  const many = [
+    ...EXTERNAL,
+    { slug: "grok-4.5", display_name: "OpenCode Go - Grok 4.5", priority: 13 },
+    { slug: "kimi-k2.7-code", display_name: "OpenCode Go - Kimi K2.7 Code", priority: 17 },
+    { slug: "mimo-v2.5", display_name: "OpenCode Go - MiniMax M2.5", priority: 19 },
+  ];
+  const assignments = buildNativeAliasAssignments(NATIVE, many);
+  const used = new Set(assignments.map(({ nativeModel }) => nativeModel.slug));
+  assert.ok(!used.has("codex-auto-review"), "codex-auto-review stays free");
+  assert.equal(assignments.length, 5, "every other captured native slug is a usable slot");
+});
+
+test("buildNativeAliasAssignments handles empty inputs", () => {
+  assert.deepEqual(buildNativeAliasAssignments([], EXTERNAL), []);
+  assert.deepEqual(buildNativeAliasAssignments(NATIVE, []), []);
+  assert.deepEqual(buildNativeAliasAssignments(null, EXTERNAL), []);
+});
+
+test("alias file round-trips versioned mappings", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-alias-file-"));
+  try {
+    const config = { nativeAliasesFile: path.join(dir, "native-aliases.json") };
+    writeNativeAliases({ "gpt-5.6-sol": "deepseek-v4-flash" }, config);
+    assert.deepEqual(readNativeAliases(config), { "gpt-5.6-sol": "deepseek-v4-flash" });
+    assert.ok(nativeAliasesPath(config).endsWith("native-aliases.json"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readNativeAliases tolerates corrupt or missing files", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-alias-corrupt-"));
+  try {
+    const config = { nativeAliasesFile: path.join(dir, "native-aliases.json") };
+    assert.deepEqual(readNativeAliases(config), {});
+    writeFileSync(path.join(dir, "native-aliases.json"), "not json", "utf8");
+    assert.deepEqual(readNativeAliases(config), {});
+    writeFileSync(path.join(dir, "native-aliases.json"), JSON.stringify({ version: 2, aliases: {} }), "utf8");
+    assert.deepEqual(readNativeAliases(config), {});
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("externalModelForAlias resolves only string mappings", () => {
+  const aliases = { "gpt-5.6-sol": "deepseek-v4-flash" };
+  assert.equal(externalModelForAlias("gpt-5.6-sol", aliases), "deepseek-v4-flash");
+  assert.equal(externalModelForAlias("gpt-5.6-terra", aliases), undefined);
+  assert.equal(externalModelForAlias("", aliases), undefined);
+  assert.equal(externalModelForAlias("gpt-5.6-sol", null), undefined);
+  assert.equal(externalModelForAlias("gpt-5.6-sol", {}), undefined);
+});
+
+test("nativeSlugForExternal finds the slot a canonical slug occupies", () => {
+  const aliases = { "gpt-5.6-sol": "deepseek-v4-flash", "gpt-5.6-terra": "glm-5" };
+  assert.equal(nativeSlugForExternal("deepseek-v4-flash", aliases), "gpt-5.6-sol");
+  assert.equal(nativeSlugForExternal("glm-5", aliases), "gpt-5.6-terra");
+  assert.equal(nativeSlugForExternal("kimi-k3", aliases), undefined);
+  assert.equal(nativeSlugForExternal("", aliases), undefined);
+});

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -687,6 +687,10 @@ export function createServices(config = loadConfig()) {
     mcpEnv: mutableConfig.mcpTransport === "stdio" ? { MODELDOCK_GATEWAY_URL: mcpUrl.replace(/\/mcp$/, "") } : {},
     model: switcherModel,
     catalogFile,
+    // Signed-out (no ChatGPT subscription): write the login-free provider table
+    // instead of the transparent openai_base_url redirect, so the App never asks
+    // for ChatGPT credentials. Mirrors the catalog's nativeMerge opt-out.
+    loginFree: mutableConfig.nativeMerge === false,
   });
   const autostart = createAutostart();
   autostart.refresh().catch(() => {});

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -9,6 +9,7 @@ import { createMcpExpressApp } from "@modelcontextprotocol/express";
 import { loadConfig, publicConfig, writeEnvFile, envFileFor, migrateEnvSecrets, isPlaceholderToken } from "./config.mjs";
 import { catalogFor } from "./catalog.mjs";
 import { nativeModelSlugs, refreshNativeCatalog } from "./native-catalog.mjs";
+import { readNativeAliases, writeNativeAliases, nativeSlugForExternal } from "./native-alias.mjs";
 import { MediaStore } from "./media-store.mjs";
 import { Metrics } from "./metrics.mjs";
 import { NATIVE_IMAGE_PATHS, relayNativeImage, relayResponses as relayGatewayResponses } from "./gateway.mjs";
@@ -462,6 +463,7 @@ async function relayGatewayRequest(req, res, services) {
     routeAffinity,
     knownModels: publishedModelIds(config),
     nativeSlugs: services.nativeSlugs,
+    nativeAliases: services.nativeAliases,
     mainModel: modelSelection?.mainModel || config.mainModel,
     visionModel: modelSelection?.visionModel || config.visionModel,
     // The native passthrough leg forwards these to ChatGPT's backend untouched.
@@ -666,6 +668,14 @@ export function createServices(config = loadConfig()) {
   // hostile local web page cannot reach the relay endpoints (see caller-key.mjs).
   const callerKey = mutableConfig.callerKey || loadOrCreateCallerKey();
   const mcpUrl = `http://${urlHost(mutableConfig.host)}:${mutableConfig.port}/mcp`;
+  // Login-free alias map (native slug -> external slug), persisted next to the
+  // catalog and read fresh by the gateway on every relay. Empty when aliasing
+  // is off (subscribers) or no native capture exists.
+  const nativeAliases = readNativeAliases(mutableConfig);
+  // The Codex config `model` key is the alias slug in login-free mode so the
+  // App picker highlights the active model; routing resolves it back through
+  // the gateway alias map.
+  const switcherModel = nativeSlugForExternal(mutableConfig.mainModel, nativeAliases) || mutableConfig.mainModel;
   const configSwitcher = new CodexConfigSwitcher({
     codexHome: mutableConfig.codexHome,
     baseUrl: `http://${urlHost(mutableConfig.host)}:${mutableConfig.port}${callerBasePath(callerKey)}`,
@@ -675,7 +685,7 @@ export function createServices(config = loadConfig()) {
     mcpCommand: mutableConfig.mcpTransport === "stdio" ? process.execPath : "",
     mcpArgs: mutableConfig.mcpTransport === "stdio" ? [path.join(dirname, "mcp-standalone.mjs")] : [],
     mcpEnv: mutableConfig.mcpTransport === "stdio" ? { MODELDOCK_GATEWAY_URL: mcpUrl.replace(/\/mcp$/, "") } : {},
-    model: mutableConfig.mainModel,
+    model: switcherModel,
     catalogFile,
   });
   const autostart = createAutostart();
@@ -696,11 +706,20 @@ export function createServices(config = loadConfig()) {
   // config at it. The CLI keeps using /v1/models; both then see one list.
   const writeCatalogFile = () => {
     try {
-      const catalog = codexModelCatalog({
+      const built = codexModelCatalog({
         ...mutableConfig,
         mainModel: modelSelection.mainModel,
         visionModel: modelSelection.visionModel,
       });
+      const { aliases = {}, ...catalog } = built;
+      if (Object.keys(aliases).length > 0) {
+        services.nativeAliases = aliases;
+        try {
+          writeNativeAliases(aliases, mutableConfig);
+        } catch (error) {
+          console.log(`[gate] native alias file write failed: ${error.message}`);
+        }
+      }
       mkdirSync(path.dirname(catalogFile), { recursive: true });
       writeFileSync(catalogFile, JSON.stringify(catalog, null, 2), "utf8");
       return catalog.models?.length || 0;
@@ -742,6 +761,7 @@ export function createServices(config = loadConfig()) {
   return Object.assign(services, {
     config: mutableConfig, runtime, metrics, mediaStore, upstreams, configSwitcher,
     autostart, updater, routeAffinity, modelSelection, callerKey, nativeSlugs,
+    nativeAliases,
     memoryStore, memoryTimer,
     refreshModelCatalog, writeCatalogFile, modelRefreshTimer,
   });

--- a/src/server.test.mjs
+++ b/src/server.test.mjs
@@ -311,12 +311,17 @@ test("config mode ON writes the wizard nativeMerge switch and drops native GPT m
   assert.ok(JSON.parse(await readFile(catalogFile, "utf8")).models.some((model) => model.slug === "gpt-5.6-luna"),
     "nativeMerge=true keeps the native GPT model in the catalog file");
 
-  // Non-subscriber (nativeMerge=false): native GPT models are dropped from the catalog.
+  // Non-subscriber (nativeMerge=false): native GPT models are dropped from the
+  // catalog; login-free aliasing republishes external models under the native
+  // slots instead, so the slot slug appears but never as an OpenAI entry.
   const nomerge = await (await post({ mode: "on", nativeMerge: false })).json();
   assert.equal(nomerge.enabled, true);
   assert.match(await readFile(envFile, "utf8"), /MODELDOCK_NATIVE_MERGE=0/);
-  assert.equal(JSON.parse(await readFile(catalogFile, "utf8")).models.some((model) => model.slug === "gpt-5.6-luna"),
-    false, "nativeMerge=false drops the native GPT model from the catalog file");
+  const nomergeCatalog = JSON.parse(await readFile(catalogFile, "utf8"));
+  const lunaEntry = nomergeCatalog.models.find((model) => model.slug === "gpt-5.6-luna");
+  assert.ok(lunaEntry, "nativeMerge=false aliases an external model onto the native slot");
+  assert.ok(!String(lunaEntry.display_name).startsWith("OpenAI -"),
+    "the aliased slot carries the external model's name, not OpenAI's");
 
   // Trial also persists the switch: a non-subscriber moving trial -> on must not get
   // the native GPT catalog back.


### PR DESCRIPTION
## 问题（Problem）

无订阅（未登录）的 Codex 桌面应用，模型选择器是空的、只显示 "Custom"：
- 桌面应用会对 `model_catalog_json` 里的条目做**原生 GPT slug 白名单精确过滤**（只认捆绑原生目录的 slug，形状相同也不放行）
- wizard 默认写的 `openai_base_url` 透明重定向形态，在没有 ChatGPT 凭据时会**死锁**（应用要求登录，但无订阅用户没有账号）

结果：22 个外部模型全部被过滤 → 列表为空、无法切换。

## 方案（Solution）

**1. native-alias（显示层）**：把外部模型重新发布为捕获到的原生 slug（保留模型自己的显示名/描述/推理等级），占满白名单槽位后选择器就有列表；canonical 条目保持 hide 供路由；网关在原生 leg 判断**之前**反查别名映射，别名请求走外部上游而不是 ChatGPT 后端。机制与 codex-router 的 login-free 相同（native-alias.mjs 同源思路）。

**2. login-free provider 表（接线层）**：wizard 检测登录态（`hasChatGptLogin`，复用已合并 PR 的成果），**未登录时自动写入 `[model_providers.modeldock]`**（keyed URL + responses wire + 自包含 bearer token），替代原来的透明重定向——全程不需要 ChatGPT 登录。订阅用户（已登录）仍走原有透明模式，行为不变。

## 测试（Tests）

- npm test：**333 / 332 通过 / 1 失败**（唯一失败是 install-macos-sim——已知的 WSL2 网络模式环境问题，无 WSL 的 CI 会自动跳过）
- 实测（隔离网关 + 临时 CODEX_HOME）：
  - wizard enable（无 auth.json）→ 自动写出免登录 provider 表（keyed URL、wire_api=responses、catalog 路径、MCP bridge 齐全）→ disable 精确恢复原配置
  - keyed 别名请求 `gpt-5.6-sol` → 反查为 deepseek-v4-flash → `status=completed`，回复正常
  - SSE 完整事件链无回归（created → output_item.added → delta → completed）
  - 桌面端实测（无账号状态）：选择器显示 7 个模型、切换可用、v4-flash 快速推理正常

## 边界（Scope，诚实声明）

本 PR 解决的是**选择器可见性、模型切换和无登录接线**。模型可用性受上游 opencode-go 平台的 Responses 适配层限制（22 模型矩阵测试：只有 **deepseek-v4-flash 和 grok-4.5** 返回完整 SSE 事件链；glm/kimi/mimo 等多数模型"网关 200 但 UI 无回复"）。这两个模型可完整使用。

## 其他（Notes）

- 已 rebase 到当前 main（v0.2.3），2 个提交，零冲突
- 槽位上限 8 个（白名单硬限制，1 个保留给 codex-auto-review），优先级可通过 MODELDOCK_MAIN_MODEL / profiles 调整
- 新增 env：MODELDOCK_NATIVE_ALIAS（默认开，仅 nativeMerge=false 时生效）、MODELDOCK_NATIVE_ALIASES_FILE、MODELDOCK_CODEX_CATALOG_FILE（网关把 catalog 写到应用实际读取的路径）