### PR TITLE
Deploy complete install assets on update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# POSIX scripts must stay LF in every checkout: a CRLF working copy breaks
+# WSL-driven macOS-install simulations and any `sh` run from a Windows tree.
+*.sh text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,10 @@ jobs:
             exit 1
           fi
       - name: Generate checksums
-        run: cd dist && sha256sum modeldock.mjs > SHA256SUMS && cat SHA256SUMS
+        run: |
+          cd dist && sha256sum modeldock.mjs mcp-standalone.mjs > SHA256SUMS
+          cd ../scripts && sha256sum install.ps1 install.sh start-hidden.ps1 restart.ps1 recover.ps1 start-hidden.sh restart.sh recover.sh >> ../dist/SHA256SUMS
+          cd ../dist && cat SHA256SUMS
       # Re-tagging an existing version must refresh its assets rather than fail:
       # `gh release create` errors when the release already exists, so upload with
       # --clobber in that case (release notes are kept).
@@ -38,7 +41,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ASSETS="dist/modeldock.mjs dist/mcp-standalone.mjs dist/SHA256SUMS scripts/install.ps1 scripts/install.sh"
+          ASSETS="dist/modeldock.mjs dist/mcp-standalone.mjs dist/SHA256SUMS scripts/install.ps1 scripts/install.sh scripts/start-hidden.ps1 scripts/restart.ps1 scripts/recover.ps1 scripts/start-hidden.sh scripts/restart.sh scripts/recover.sh"
           # Delete any existing release first (the tag itself is kept). Uploading into
           # one is not safe: deleting a tag turns its release into a draft, and a draft
           # keeps accepting asset uploads while serving 404 on the public download URLs -
@@ -51,7 +54,7 @@ jobs:
             --title "ModelDock $GITHUB_REF_NAME" \
             --generate-notes
           # A green workflow is not proof the assets are reachable - verify.
-          for f in modeldock.mjs mcp-standalone.mjs SHA256SUMS install.ps1 install.sh; do
+          for f in modeldock.mjs mcp-standalone.mjs SHA256SUMS install.ps1 install.sh start-hidden.ps1 restart.ps1 recover.ps1 start-hidden.sh restart.sh recover.sh; do
             gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name' | grep -qx "$f" \
               || { echo "asset $f missing from the published release" >&2; exit 1; }
           done

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modeldock-opencode-go-gate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modeldock-opencode-go-gate",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@modelcontextprotocol/express": "2.0.0",
         "@modelcontextprotocol/node": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,9 +1230,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.33",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
-      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/server.mjs",
     "dev": "node --watch src/server.mjs",
-    "pretest": "node scripts/cleanup-sandbox.mjs",
+    "pretest": "node scripts/cleanup-sandbox.mjs && node scripts/sync-installer-helpers.mjs --check",
     "test": "node --test test/*.test.mjs src/*.test.mjs",
     "sandbox:clean": "node scripts/cleanup-sandbox.mjs",
     "test:install": "node --test test/install-mock.test.mjs test/install-macos-sim.test.mjs",
@@ -31,7 +31,8 @@
     "esbuild": "^0.28.1"
   },
   "overrides": {
-    "@hono/node-server": "2.0.12"
+    "@hono/node-server": "2.0.12",
+    "hono": "4.12.34"
   },
   "allowScripts": {
     "esbuild@0.28.1": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modeldock-opencode-go-gate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "description": "Give DeepSeek eyes, ears, a voice, a web connection, and a memory inside Codex - a thin local Responses bridge for OpenCode Go and DeepSeek official, with native GPT passthrough and live token, latency, and trace observability.",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -222,11 +222,17 @@ if (-not $nodeExe) {
 # command starts with a quoted program path, so wrap the whole command in one extra
 # pair of quotes (the ""prog" args" form).
 $log = Join-Path $root "modeldock.log"
-# Rotate at startup, one previous generation (same policy as scripts/start-hidden.ps1):
+# Rotate at startup, one previous generation (like codex-router's log-rotation):
 # the log is append-only for the life of the process, so a cap on growth can only
-# be applied between runs.
+# be applied between runs. 32 MB keeps roughly a month of daily use. Rotation is
+# best-effort: a previous gateway whose handles have not released must not fail
+# this hidden start.
 if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  try {
     Move-Item -LiteralPath $log -Destination "$log.1" -Force
+  } catch {
+    Write-Output "WARNING: could not rotate modeldock.log: $($_.Exception.Message)"
+  }
 }
 Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden
 '@ | Out-File -FilePath $launcher -Encoding ascii
@@ -309,17 +315,12 @@ if ($listener) {
 }
 
 $log = Join-Path $root "modeldock.log"
-# Rotate at startup, one previous generation (same policy as start-hidden.ps1):
-# the log is append-only for the life of the process, so a cap on growth can
-# only be applied between runs.
-if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
-  Move-Item -LiteralPath $log -Destination "$log.1" -Force
-}
 
 # The old gateway's stdout/stderr handles can linger for a moment after
-# Stop-Process. Wait for the log to become writable; if it stays locked, fall
-# back to a per-run log file so the redirect never races the dying process's
-# file handles.
+# Stop-Process. Wait for the log to become writable BEFORE rotating: an
+# in-place Move-Item on a still-locked file fails, and that failure used to
+# abort the restart. If it stays locked, fall back to a per-run log file so
+# the redirect never races the dying process's file handles.
 function Test-WritableFile($file) {
   try {
     $probe = [System.IO.File]::Open($file, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
@@ -341,6 +342,17 @@ if (-not $logsReady) {
   $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
   $log = Join-Path $root "modeldock-$stamp.log"
   Write-Status "WARNING: modeldock.log was still locked; using per-run log ($log)"
+} elseif ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  # Rotate at startup, one previous generation (same policy as start-hidden.ps1):
+  # the log is append-only for the life of the process, so a cap on growth can
+  # only be applied between runs. 32 MB keeps roughly a month of daily use.
+  try {
+    Move-Item -LiteralPath $log -Destination "$log.1" -Force
+  } catch {
+    # Rotation is best-effort now that the lock wait passed; a raced lock must
+    # not turn a restart into a failure.
+    Write-Status "WARNING: could not rotate modeldock.log: $($_.Exception.Message)"
+  }
 }
 
 # Prefer an explicit path, then a bundled Node under <root>\node (the installer
@@ -411,6 +423,9 @@ exit 1
 # Manual recovery menu: restart the gateway or restore the native Codex route.
 $recover = Join-Path $root "scripts\recover.ps1"
 @'
+# ModelDock manual recovery menu.
+# Choose gateway restart or restore the last native Codex configuration.
+
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
 $port = 4097
@@ -418,7 +433,9 @@ $envFile = Join-Path $root ".env"
 if (Test-Path -LiteralPath $envFile) {
   $line = Select-String -Path $envFile -Pattern '^MODELDOCK_PORT=' | Select-Object -First 1
   $parsed = 0
-  if ($line -and [int]::TryParse(($line.Line -replace '^MODELDOCK_PORT=', ''), [ref]$parsed) -and $parsed -gt 0) { $port = $parsed }
+  if ($line -and [int]::TryParse(($line.Line -replace '^MODELDOCK_PORT=', ''), [ref]$parsed) -and $parsed -gt 0) {
+    $port = $parsed
+  }
 }
 
 # Start-at-login repair: when a start-at-login decision was recorded (the mark
@@ -459,6 +476,70 @@ function Repair-Autostart {
   } finally { if ($runKey) { $runKey.Close() } }
 }
 
+function Restore-PreviousUpdate {
+  $rollbackRoot = Join-Path $root ".modeldock-rollback"
+  $marker = Join-Path $rollbackRoot "current"
+  if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) { return $false }
+  $name = [System.IO.File]::ReadAllText($marker).Trim()
+  if (-not $name -or [System.IO.Path]::GetFileName($name) -ne $name) { throw "invalid update rollback marker" }
+  $rollbackDir = Join-Path $rollbackRoot $name
+  $manifestPath = Join-Path $rollbackDir "manifest.json"
+  $manifest = [System.IO.File]::ReadAllText($manifestPath) | ConvertFrom-Json
+  $rootPrefix = [System.IO.Path]::GetFullPath($root).TrimEnd('\') + '\'
+  $rollbackPrefix = [System.IO.Path]::GetFullPath($rollbackDir).TrimEnd('\') + '\'
+  $prepared = @()
+  $applied = 0
+  try {
+    foreach ($entry in $manifest.files) {
+      $relative = ([string]$entry.path).Replace('/', '\')
+      $target = [System.IO.Path]::GetFullPath((Join-Path $root $relative))
+      if (-not $target.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "rollback path escaped install root: $relative"
+      }
+      $stage = "$target.rollback-stage-$PID"
+      $current = "$target.rollback-current-$PID"
+      Remove-Item -LiteralPath $stage, $current -Force -ErrorAction SilentlyContinue
+      [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($target)) | Out-Null
+      $currentExisted = Test-Path -LiteralPath $target -PathType Leaf
+      if ($currentExisted) { Copy-Item -LiteralPath $target -Destination $current -Force }
+      $restore = [bool]$entry.existed
+      if ($restore) {
+        $source = [System.IO.Path]::GetFullPath((Join-Path $rollbackDir $relative))
+        if (-not $source.StartsWith($rollbackPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not (Test-Path -LiteralPath $source -PathType Leaf)) {
+          throw "rollback file is missing: $relative"
+        }
+        Copy-Item -LiteralPath $source -Destination $stage -Force
+      }
+      $prepared += [pscustomobject]@{ Target = $target; Stage = $stage; Current = $current; CurrentExisted = $currentExisted; Restore = $restore }
+    }
+    foreach ($item in $prepared) {
+      if ($item.Restore) {
+        if (Test-Path -LiteralPath $item.Target -PathType Leaf) {
+          [System.IO.File]::Replace($item.Stage, $item.Target, $null)
+        } else {
+          Move-Item -LiteralPath $item.Stage -Destination $item.Target
+        }
+      } elseif (Test-Path -LiteralPath $item.Target) {
+        Remove-Item -LiteralPath $item.Target -Force
+      }
+      $applied += 1
+    }
+  } catch {
+    for ($index = $applied - 1; $index -ge 0; $index -= 1) {
+      $item = $prepared[$index]
+      if ($item.CurrentExisted) { Copy-Item -LiteralPath $item.Current -Destination $item.Target -Force }
+      else { Remove-Item -LiteralPath $item.Target -Force -ErrorAction SilentlyContinue }
+    }
+    throw
+  } finally {
+    foreach ($item in $prepared) {
+      Remove-Item -LiteralPath $item.Stage, $item.Current -Force -ErrorAction SilentlyContinue
+    }
+  }
+  return $true
+}
+
 function Restart-Gateway {
   Repair-Autostart
   $restart = Join-Path $root "scripts\restart.ps1"
@@ -466,47 +547,80 @@ function Restart-Gateway {
     throw "restart.ps1 is missing from $root"
   }
   & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
-  if ($LASTEXITCODE -ne 0) { throw "gateway restart failed" }
+  if ($LASTEXITCODE -ne 0) {
+    # A bundle and its bridge/lifecycle helpers are one versioned unit. Restore
+    # the complete snapshot transactionally before retrying the old restart.
+    if (Restore-PreviousUpdate) {
+      Write-Output "New installed version did not become healthy; restored the complete previous version set."
+      & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
+      if ($LASTEXITCODE -eq 0) { return }
+    }
+    throw "gateway restart failed"
+  }
 }
+
 function Restore-Native {
+  $uri = "http://127.0.0.1:$port/api/config/disable"
   try {
-    Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:$port/api/config/disable" -TimeoutSec 3 | Out-Null
+    Invoke-RestMethod -Method Post -Uri $uri -TimeoutSec 3 | Out-Null
     Write-Output "Codex native route restored through the running gateway."
     return
-  } catch { Write-Output "Gateway is unavailable; restoring from the local backup." }
+  } catch {
+    Write-Output "Gateway is unavailable; restoring from the local backup."
+  }
+
   $codexHome = if ($env:MODELDOCK_CODEX_HOME) { $env:MODELDOCK_CODEX_HOME } elseif ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE ".codex" }
   $statePath = Join-Path $codexHome "modeldock\config-switch-state.json"
   if (-not (Test-Path -LiteralPath $statePath)) { throw "ModelDock switch state was not found: $statePath" }
   $state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
-  if (-not $state.enabled) { Write-Output "Codex is already on the native route."; return }
+  if (-not $state.enabled) {
+    Write-Output "Codex is already on the native route."
+    return
+  }
   $backup = [System.IO.Path]::GetFullPath([string]$state.backupPath)
   if (-not (Test-Path -LiteralPath $backup)) { throw "ModelDock backup is missing: $backup" }
   $config = Join-Path $codexHome "config.toml"
   if (Test-Path -LiteralPath $config) {
-    Copy-Item -LiteralPath $config -Destination "$config.native-recovery-$(Get-Date -Format yyyyMMdd-HHmmss).bak"
-    if (-not $state.originalExisted) { Remove-Item -LiteralPath $config -Force } else { Copy-Item -LiteralPath $backup -Destination $config -Force }
-  } elseif ($state.originalExisted) { Copy-Item -LiteralPath $backup -Destination $config -Force }
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    Copy-Item -LiteralPath $config -Destination "$config.native-recovery-$stamp.bak"
+    if (-not $state.originalExisted) { Remove-Item -LiteralPath $config -Force }
+    else { Copy-Item -LiteralPath $backup -Destination $config -Force }
+  } elseif ($state.originalExisted) {
+    Copy-Item -LiteralPath $backup -Destination $config -Force
+  }
   # Rebuild the state as a fresh ordered map: Windows PowerShell 5.1 throws when a
-  # property that ConvertFrom-Json did not create is set via dot assignment.
+  # property that ConvertFrom-Json did not create (here lastBackupPath) is set via
+  # dot assignment, so copy the existing keys and override the ones we change.
   $out = [ordered]@{}
   foreach ($p in $state.PSObject.Properties) { $out[$p.Name] = $p.Value }
-  $out['enabled'] = $false; $out['restartRequired'] = $true; $out['lastBackupPath'] = $backup
+  $out['enabled'] = $false
+  $out['restartRequired'] = $true
+  $out['lastBackupPath'] = $backup
   $out['changedAt'] = (Get-Date).ToUniversalTime().ToString("o")
   $tmp = "$statePath.$PID.tmp"
-  # Write UTF-8 without a BOM: Node reads this file as UTF-8 JSON.
+  # Write UTF-8 without a BOM: the gateway reads this file with Node's utf8 and a
+  # BOM would make JSON.parse fail (Set-Content -Encoding utf8 emits a BOM on 5.1).
   [System.IO.File]::WriteAllText($tmp, ($out | ConvertTo-Json -Depth 10), (New-Object System.Text.UTF8Encoding($false)))
   Move-Item -LiteralPath $tmp -Destination $statePath -Force
   Write-Output "Codex native route restored from $backup"
   Write-Output "Fully quit and restart Codex."
 }
+
+Write-Output ""
 Write-Output "ModelDock manual recovery"
 Write-Output "1. Restart ModelDock gateway"
 Write-Output "2. Restore Codex native route"
 Write-Output "Q. Quit"
 $choice = (Read-Host "Choose 1, 2, or Q").Trim().ToUpperInvariant()
 try {
-  if ($choice -eq "1") { Restart-Gateway } elseif ($choice -eq "2") { Restore-Native } elseif ($choice -ne "Q" -and $choice -ne "") { throw "Unknown choice: $choice" }
-} catch { Write-Error $_.Exception.Message; exit 1 }
+  if ($choice -eq "1") { Restart-Gateway }
+  elseif ($choice -eq "2") { Restore-Native }
+  elseif ($choice -eq "Q" -or $choice -eq "") { exit 0 }
+  else { throw "Unknown choice: $choice" }
+} catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
 '@ | Out-File -FilePath $recover -Encoding ascii
 
 # 2.5. Install the content-to-video skill into the Codex skills directory.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -150,6 +150,35 @@ Write-Host "  downloading MCP stdio bridge..."
 Invoke-WebRequest -UseBasicParsing -Uri $bridgeUrl -OutFile $bridge
 Write-Host ("  saved {0} ({1:N2} MB)" -f $bridge, ((Get-Item $bridge).Length / 1MB))
 
+# Integrity: releases publish a SHA256SUMS covering every asset. Verify the two
+# files we just downloaded against it and refuse to leave a corrupt install
+# behind. MODELDOCK_SUMS_URL redirects the lookup (mock-install tests).
+$sumsUrl = if ($env:MODELDOCK_SUMS_URL) { $env:MODELDOCK_SUMS_URL } else { "https://github.com/$repo/releases/latest/download/SHA256SUMS" }
+function Assert-Downloaded([string]$file, [string]$name) {
+  $sumsText = (Invoke-WebRequest -UseBasicParsing -Uri $sumsUrl -TimeoutSec 60).Content
+  $line = ($sumsText -split "`r?`n") | Where-Object { $_ -match "(?i)^[0-9a-f]{64}\s+\*?$([regex]::Escape($name))\s*$" } | Select-Object -First 1
+  if (-not $line) {
+    Remove-Item -LiteralPath $file -Force
+    throw "SHA256SUMS has no entry for $name; refusing to keep an unverified download"
+  }
+  $expected = ($line -split '\s+')[0].ToLowerInvariant()
+  $hasher = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $actual = [System.BitConverter]::ToString(
+      $hasher.ComputeHash([System.IO.File]::ReadAllBytes($file))
+    ).Replace("-", "").ToLowerInvariant()
+  } finally {
+    $hasher.Dispose()
+  }
+  if ($actual -ne $expected) {
+    Remove-Item -LiteralPath $file -Force
+    throw "Checksum mismatch for $name (expected $expected, got $actual)"
+  }
+}
+Assert-Downloaded $bundle "modeldock.mjs"
+Assert-Downloaded $bridge "mcp-standalone.mjs"
+Write-Host "  release assets verified against SHA256SUMS"
+
 # Hidden launcher (same content as the repo's scripts/start-hidden.ps1). Written by the
 # installer so a single-file download still gets autostart + self-update restarts.
 $launcher = Join-Path $root "scripts\start-hidden.ps1"
@@ -297,7 +326,9 @@ if (-not $nodeExe) {
 $server = Join-Path $root "src\server.mjs"
 if (-not (Test-Path -LiteralPath $server)) { $server = Join-Path $root "dist\modeldock.mjs" }
 
-Start-Process -FilePath $nodeExe -ArgumentList $server -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+# Quote the script path so an install dir with a space (e.g. "Chen Bao") is not
+# split into two argv entries by node's CRT.
+Start-Process -FilePath $nodeExe -ArgumentList "`"$server`"" -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
 Write-Output "restart.ps1: started gateway from $root (logs: $logDir)"
 
 for ($i = 0; $i -lt 40; $i += 1) {
@@ -388,10 +419,12 @@ function Restore-Native {
     Copy-Item -LiteralPath $config -Destination "$config.native-recovery-$(Get-Date -Format yyyyMMdd-HHmmss).bak"
     if (-not $state.originalExisted) { Remove-Item -LiteralPath $config -Force } else { Copy-Item -LiteralPath $backup -Destination $config -Force }
   } elseif ($state.originalExisted) { Copy-Item -LiteralPath $backup -Destination $config -Force }
-  $state.enabled = $false; $state.restartRequired = $true; $state.lastBackupPath = $backup
-  $state.changedAt = (Get-Date).ToUniversalTime().ToString("o")
+  $out = [ordered]@{}
+  foreach ($p in $state.PSObject.Properties) { $out[$p.Name] = $p.Value }
+  $out['enabled'] = $false; $out['restartRequired'] = $true; $out['lastBackupPath'] = $backup
+  $out['changedAt'] = (Get-Date).ToUniversalTime().ToString("o")
   $tmp = "$statePath.$PID.tmp"
-  $state | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $tmp -Encoding utf8
+  [System.IO.File]::WriteAllText($tmp, ($out | ConvertTo-Json -Depth 10), (New-Object System.Text.UTF8Encoding($false)))
   Move-Item -LiteralPath $tmp -Destination $statePath -Force
   Write-Output "Codex native route restored from $backup"
   Write-Output "Fully quit and restart Codex."

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -222,6 +222,12 @@ if (-not $nodeExe) {
 # command starts with a quoted program path, so wrap the whole command in one extra
 # pair of quotes (the ""prog" args" form).
 $log = Join-Path $root "modeldock.log"
+# Rotate at startup, one previous generation (same policy as scripts/start-hidden.ps1):
+# the log is append-only for the life of the process, so a cap on growth can only
+# be applied between runs.
+if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+    Move-Item -LiteralPath $log -Destination "$log.1" -Force
+}
 Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden
 '@ | Out-File -FilePath $launcher -Encoding ascii
 
@@ -245,6 +251,14 @@ $ErrorActionPreference = "Stop"
 
 $root = Split-Path -Parent $PSScriptRoot
 $envFile = Join-Path $root ".env"
+
+# Status lines go to both stdout and stderr. Callers (CI, the model shell, the
+# dashboard) sometimes capture only one stream; a hidden launcher must never
+# fail silently.
+function Write-Status($message) {
+  Write-Output $message
+  [Console]::Error.WriteLine($message)
+}
 
 $port = 4097
 if (Test-Path $envFile) {
@@ -275,8 +289,8 @@ if ($listener) {
         $ownerRoot = [System.IO.Path]::GetFullPath($owner.root)
         $thisRoot = [System.IO.Path]::GetFullPath($root)
         if ($ownerRoot -ne $thisRoot) {
-          Write-Output "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
-          Write-Output "Re-run with -Force to take the port over deliberately."
+          Write-Status "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
+          Write-Status "Re-run with -Force to take the port over deliberately."
           exit 1
         }
       }
@@ -284,20 +298,50 @@ if ($listener) {
       # Unreadable owner file: fall through and behave as before.
     }
   }
-  Write-Output "restart.ps1: stopping gateway (PID $oldPid, port $port)"
+  Write-Status "restart.ps1: stopping gateway (PID $oldPid, port $port)"
   Stop-Process -Id $oldPid -Force
   for ($i = 0; $i -lt 20; $i += 1) {
     Start-Sleep -Milliseconds 250
     if (-not (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)) { break }
   }
 } else {
-  Write-Output "restart.ps1: no gateway on port $port; starting fresh"
+  Write-Status "restart.ps1: no gateway on port $port; starting fresh"
 }
 
-$logDir = Join-Path $env:TEMP "modeldock"
-New-Item -ItemType Directory -Force -Path $logDir | Out-Null
-$stdout = Join-Path $logDir "gateway.log"
-$stderr = Join-Path $logDir "gateway.err.log"
+$log = Join-Path $root "modeldock.log"
+# Rotate at startup, one previous generation (same policy as start-hidden.ps1):
+# the log is append-only for the life of the process, so a cap on growth can
+# only be applied between runs.
+if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  Move-Item -LiteralPath $log -Destination "$log.1" -Force
+}
+
+# The old gateway's stdout/stderr handles can linger for a moment after
+# Stop-Process. Wait for the log to become writable; if it stays locked, fall
+# back to a per-run log file so the redirect never races the dying process's
+# file handles.
+function Test-WritableFile($file) {
+  try {
+    $probe = [System.IO.File]::Open($file, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    $probe.Close()
+    return $true
+  } catch {
+    return $false
+  }
+}
+$logsReady = $false
+for ($i = 0; $i -lt 20; $i += 1) {
+  if (Test-WritableFile $log) {
+    $logsReady = $true
+    break
+  }
+  Start-Sleep -Milliseconds 250
+}
+if (-not $logsReady) {
+  $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $log = Join-Path $root "modeldock-$stamp.log"
+  Write-Status "WARNING: modeldock.log was still locked; using per-run log ($log)"
+}
 
 # Prefer an explicit path, then a bundled Node under <root>\node (the installer
 # downloads Node 22 LTS there when none is on PATH), then PATH.
@@ -316,7 +360,7 @@ if (-not $nodeExe) {
 }
 if (-not $nodeExe) { $nodeExe = (Get-Command node -ErrorAction SilentlyContinue).Source }
 if (-not $nodeExe) {
-  Write-Output "ERROR: node.exe not found; install Node 22+ or re-run the ModelDock installer"
+  Write-Status "ERROR: node.exe not found; install Node 22+ or re-run the ModelDock installer"
   exit 1
 }
 
@@ -326,30 +370,41 @@ if (-not $nodeExe) {
 $server = Join-Path $root "src\server.mjs"
 if (-not (Test-Path -LiteralPath $server)) { $server = Join-Path $root "dist\modeldock.mjs" }
 
-# Quote the script path so an install dir with a space (e.g. "Chen Bao") is not
-# split into two argv entries by node's CRT.
-Start-Process -FilePath $nodeExe -ArgumentList "`"$server`"" -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
-Write-Output "restart.ps1: started gateway from $root (logs: $logDir)"
+try {
+  # Quote both paths: an installed layout under a home dir with a space
+  # (e.g. "C:\Users\Chen Bao\.modeldock") would otherwise be split by node's
+  # CRT into two argv entries and fail with "Cannot find module". cmd.exe does
+  # the >> redirection so stdout and stderr share the same log file as the
+  # start-hidden launcher (and the "check modeldock.log" guidance).
+  Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden
+} catch {
+  Write-Status "ERROR: failed to start gateway: $($_.Exception.Message)"
+  exit 1
+}
+Write-Status "restart.ps1: started gateway from $root (logs: $log)"
 
 for ($i = 0; $i -lt 40; $i += 1) {
   Start-Sleep -Milliseconds 250
   try {
     Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2 -UseBasicParsing | Out-Null
-    Write-Output "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    Write-Status "restart.ps1: gateway healthy at http://127.0.0.1:$port"
     exit 0
   } catch {
-    # A returned HTTP status (e.g. 503 before a token is set) still proves the
-    # gateway is up; only a connection failure means it is not.
+    # A returned HTTP status (e.g. 503 before a token is configured) still proves
+    # the gateway is up and listening - only a connection failure means it is not.
     if ($_.Exception.Response) {
-      Write-Output "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
+      Write-Status "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
       exit 0
     }
-    # Otherwise still booting; keep polling.
+    # Otherwise still booting / connection refused; keep polling.
   }
 }
 
-Write-Output "ERROR: gateway did not become healthy within 10s"
-if (Test-Path $stderr) { Get-Content $stderr -Tail 10 -ErrorAction SilentlyContinue }
+Write-Status "ERROR: gateway did not become healthy within 10s"
+if (Test-Path $log) {
+  $tail = Get-Content $log -Tail 10 -ErrorAction SilentlyContinue
+  if ($tail) { $tail | ForEach-Object { [Console]::Error.WriteLine($_) } }
+}
 exit 1
 '@ | Out-File -FilePath $restart -Encoding ascii
 
@@ -402,7 +457,11 @@ function Repair-Autostart {
 
 function Restart-Gateway {
   Repair-Autostart
-  & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $root "scripts\restart.ps1")
+  $restart = Join-Path $root "scripts\restart.ps1"
+  if (-not (Test-Path -LiteralPath $restart)) {
+    throw "restart.ps1 is missing from $root"
+  }
+  & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
   if ($LASTEXITCODE -ne 0) { throw "gateway restart failed" }
 }
 function Restore-Native {
@@ -423,11 +482,14 @@ function Restore-Native {
     Copy-Item -LiteralPath $config -Destination "$config.native-recovery-$(Get-Date -Format yyyyMMdd-HHmmss).bak"
     if (-not $state.originalExisted) { Remove-Item -LiteralPath $config -Force } else { Copy-Item -LiteralPath $backup -Destination $config -Force }
   } elseif ($state.originalExisted) { Copy-Item -LiteralPath $backup -Destination $config -Force }
+  # Rebuild the state as a fresh ordered map: Windows PowerShell 5.1 throws when a
+  # property that ConvertFrom-Json did not create is set via dot assignment.
   $out = [ordered]@{}
   foreach ($p in $state.PSObject.Properties) { $out[$p.Name] = $p.Value }
   $out['enabled'] = $false; $out['restartRequired'] = $true; $out['lastBackupPath'] = $backup
   $out['changedAt'] = (Get-Date).ToUniversalTime().ToString("o")
   $tmp = "$statePath.$PID.tmp"
+  # Write UTF-8 without a BOM: Node reads this file as UTF-8 JSON.
   [System.IO.File]::WriteAllText($tmp, ($out | ConvertTo-Json -Depth 10), (New-Object System.Text.UTF8Encoding($false)))
   Move-Item -LiteralPath $tmp -Destination $statePath -Force
   Write-Output "Codex native route restored from $backup"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -421,10 +421,14 @@ if (Test-Path -LiteralPath $envFile) {
   if ($line -and [int]::TryParse(($line.Line -replace '^MODELDOCK_PORT=', ''), [ref]$parsed) -and $parsed -gt 0) { $port = $parsed }
 }
 
-# Start-at-login repair: when the autostart decision mark exists but the Run key
-# is gone (registry cleanup, earlier toggle-off that deleted the key), re-write
-# the login entry before restarting the gateway. A missing mark means no decision
-# was ever recorded, so an explicit off is never silently overridden.
+# Start-at-login repair: when a start-at-login decision was recorded (the mark
+# exists) but the Run key is gone - registry cleanup, or an earlier toggle-off that
+# deleted the key - re-write the login entry before restarting the gateway.
+# By design autostart is a re-asserted default: the gateway re-enables it on every
+# version change (see initAutostartDefault), and this repair restores it on every
+# recover run as well. A toggle-off is therefore NOT permanent across a recover or
+# an update - to keep it off, turn it off again afterward. Only a missing mark (no
+# decision ever recorded) is left untouched.
 $autostartKeyName = if ($env:MODELDOCK_AUTOSTART_KEY) { $env:MODELDOCK_AUTOSTART_KEY } else { "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" }
 $autostartValueName = if ($env:MODELDOCK_AUTOSTART_NAME) { $env:MODELDOCK_AUTOSTART_NAME } else { "ModelDock" }
 $autostartStateDir = if ($env:MODELDOCK_STATE_DIR) { $env:MODELDOCK_STATE_DIR } else { $root }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -334,13 +334,17 @@ Write-Output "restart.ps1: started gateway from $root (logs: $logDir)"
 for ($i = 0; $i -lt 40; $i += 1) {
   Start-Sleep -Milliseconds 250
   try {
-    $health = Invoke-RestMethod -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2
-    if ($health.ok) {
-      Write-Output "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2 -UseBasicParsing | Out-Null
+    Write-Output "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    exit 0
+  } catch {
+    # A returned HTTP status (e.g. 503 before a token is set) still proves the
+    # gateway is up; only a connection failure means it is not.
+    if ($_.Exception.Response) {
+      Write-Output "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
       exit 0
     }
-  } catch {
-    # Gateway still booting; keep polling.
+    # Otherwise still booting; keep polling.
   }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -203,7 +203,7 @@ else
 fi
 PORT="${MODELDOCK_PORT:-4097}"
 if [ -f "$ROOT/.env" ]; then
-  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1)"
+  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1 | tr -d '\r' || true)"
   [ -n "$ENV_PORT" ] && PORT="$ENV_PORT"
 fi
 if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz"; then
@@ -226,7 +226,9 @@ if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then
   if [ -n "$BEST_BIN" ]; then
     NODE_BIN="$BEST_BIN"
   else
-    NODE_BIN="$(command -v node)"
+    # `set -e` turns a failed command substitution into an immediate exit, so
+    # the friendly error below would never run; keep the substitution false-safe.
+    NODE_BIN="$(command -v node || true)"
   fi
 fi
 if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then
@@ -795,6 +797,15 @@ if [ "$SKIP_START" != "1" ] && [ "$(uname -s)" = "Darwin" ]; then
   PLIST_DIR="${MODELDOCK_AUTOSTART_PLIST_DIR:-$HOME/Library/LaunchAgents}"
   PLIST="$PLIST_DIR/com.modeldock.gateway.plist"
   mkdir -p "$PLIST_DIR"
+  # plist is XML: a user path containing & < > would otherwise break launchd.
+  xml_escape() {
+    printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+  }
+  NODE_DIR="$(dirname "$NODE_BIN")"
+  PLIST_PATH="$(xml_escape "$NODE_DIR:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")"
+  PLIST_NODE="$(xml_escape "$NODE_BIN")"
+  PLIST_SERVER="$(xml_escape "$SERVER")"
+  PLIST_ROOT="$(xml_escape "$ROOT")"
   cat > "$PLIST" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -803,20 +814,20 @@ if [ "$SKIP_START" != "1" ] && [ "$(uname -s)" = "Darwin" ]; then
   <key>Label</key><string>com.modeldock.gateway</string>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>PATH</key><string>$(dirname "$NODE_BIN"):/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>MODELDOCK_NODE_PATH</key><string>$NODE_BIN</string>
+    <key>PATH</key><string>$PLIST_PATH</string>
+    <key>MODELDOCK_NODE_PATH</key><string>$PLIST_NODE</string>
   </dict>
   <key>ProgramArguments</key>
   <array>
-    <string>$NODE_BIN</string>
-    <string>$SERVER</string>
+    <string>$PLIST_NODE</string>
+    <string>$PLIST_SERVER</string>
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>10</integer>
-  <key>WorkingDirectory</key><string>$ROOT</string>
-  <key>StandardOutPath</key><string>$ROOT/modeldock.log</string>
-  <key>StandardErrorPath</key><string>$ROOT/modeldock.log</string>
+  <key>WorkingDirectory</key><string>$PLIST_ROOT</string>
+  <key>StandardOutPath</key><string>$PLIST_ROOT/modeldock.log</string>
+  <key>StandardErrorPath</key><string>$PLIST_ROOT/modeldock.log</string>
 </dict>
 </plist>
 EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -155,6 +155,37 @@ echo "  downloading MCP stdio bridge..."
 curl -fL --progress-bar "$BRIDGE_URL" -o "$BRIDGE"
 echo "  saved $BRIDGE"
 
+# Integrity: releases publish a SHA256SUMS covering every asset. Verify the two
+# files just downloaded against it and refuse to leave a corrupt install behind.
+# MODELDOCK_SUMS_URL redirects the lookup (mock-install tests).
+SUMS_URL="${MODELDOCK_SUMS_URL:-https://github.com/$REPO/releases/latest/download/SHA256SUMS}"
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_CMD="sha256sum"
+else
+  HASH_CMD="shasum -a 256"
+fi
+verify_download() {
+  file="$1"
+  name="$2"
+  sums="$(curl -fsSL --max-time 60 "$SUMS_URL" 2>/dev/null || true)"
+  line="$(printf '%s\n' "$sums" | grep -E "^[0-9a-f]{64}[[:space:]]+\*?${name}[[:space:]]*$" | head -n 1 || true)"
+  if [ -z "$line" ]; then
+    echo "ERROR: SHA256SUMS has no entry for $name; refusing to keep an unverified download" >&2
+    rm -f "$file"
+    exit 1
+  fi
+  expected="$(printf '%s' "$line" | awk '{print tolower($1)}')"
+  actual="$($HASH_CMD "$file" 2>/dev/null | awk '{print tolower($1)}')"
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: checksum mismatch for $name (expected $expected, got $actual)" >&2
+    rm -f "$file"
+    exit 1
+  fi
+}
+verify_download "$BUNDLE" "modeldock.mjs"
+verify_download "$BRIDGE" "mcp-standalone.mjs"
+echo "  release assets verified against SHA256SUMS"
+
 # Background launcher (same content as the repo's scripts/start-hidden.sh). Written by
 # the installer so a single-file download still gets autostart + self-update restarts.
 LAUNCHER="$ROOT/scripts/start-hidden.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -341,19 +341,22 @@ if (-not $nodeExe) {
 $server = Join-Path $root "src\server.mjs"
 if (-not (Test-Path -LiteralPath $server)) { $server = Join-Path $root "dist\modeldock.mjs" }
 
-Start-Process -FilePath $nodeExe -ArgumentList $server -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+# Quote the script path so an install dir with a space is not split into two argv entries.
+Start-Process -FilePath $nodeExe -ArgumentList "`"$server`"" -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
 Write-Output "restart.ps1: started gateway from $root (logs: $logDir)"
 
 for ($i = 0; $i -lt 40; $i += 1) {
   Start-Sleep -Milliseconds 250
   try {
-    $health = Invoke-RestMethod -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2
-    if ($health.ok) {
-      Write-Output "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2 -UseBasicParsing | Out-Null
+    Write-Output "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    exit 0
+  } catch {
+    if ($_.Exception.Response) {
+      Write-Output "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
       exit 0
     }
-  } catch {
-    # Gateway still booting; keep polling.
+    # Otherwise still booting; keep polling.
   }
 }
 
@@ -490,7 +493,8 @@ wait_for_health() {
   old_pid="${1:-}"
   i=0
   while [ "$i" -lt 40 ]; do
-    if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    # No -f: a 503 (up but awaiting a token) still proves the process is listening.
+    if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
       new_pid="$(find_listener_pid)"
       if [ -z "$old_pid" ] || [ -z "$new_pid" ] || [ "$new_pid" != "$old_pid" ]; then
         status "restart.sh: gateway healthy at http://127.0.0.1:$PORT"
@@ -616,7 +620,8 @@ restart_gateway() {
   "$ROOT/scripts/start-hidden.sh"
   i=0
   while [ "$i" -lt 40 ]; do
-    if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    # No -f: a 503 before a token is set still proves the gateway is listening.
+    if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
       if [ "$has_lsof" -eq 1 ]; then
         new_pid="$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)"
         if [ -n "$new_pid" ] && [ "$new_pid" != "$old_pid" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -238,7 +238,14 @@ fi
 cd "$ROOT"
 # Log instead of discarding: a background start that dies (bad node, port in use,
 # missing file) is otherwise completely silent for the user.
-nohup "$NODE_BIN" "$SERVER" >>"$ROOT/modeldock.log" 2>&1 &
+LOG="$ROOT/modeldock.log"
+# Rotate at startup, one previous generation (like codex-router's log-rotation):
+# the log is append-only for the life of the process, so a cap on growth can only
+# be applied between runs. 32 MB keeps roughly a month of daily use.
+if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 33554432 ]; then
+  mv -f "$LOG" "$LOG.1"
+fi
+nohup "$NODE_BIN" "$SERVER" >>"$LOG" 2>&1 &
 EOF
 chmod +x "$LAUNCHER"
 
@@ -262,6 +269,14 @@ $ErrorActionPreference = "Stop"
 
 $root = Split-Path -Parent $PSScriptRoot
 $envFile = Join-Path $root ".env"
+
+# Status lines go to both stdout and stderr. Callers (CI, the model shell, the
+# dashboard) sometimes capture only one stream; a hidden launcher must never
+# fail silently.
+function Write-Status($message) {
+  Write-Output $message
+  [Console]::Error.WriteLine($message)
+}
 
 $port = 4097
 if (Test-Path $envFile) {
@@ -292,8 +307,8 @@ if ($listener) {
         $ownerRoot = [System.IO.Path]::GetFullPath($owner.root)
         $thisRoot = [System.IO.Path]::GetFullPath($root)
         if ($ownerRoot -ne $thisRoot) {
-          Write-Output "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
-          Write-Output "Re-run with -Force to take the port over deliberately."
+          Write-Status "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
+          Write-Status "Re-run with -Force to take the port over deliberately."
           exit 1
         }
       }
@@ -301,20 +316,56 @@ if ($listener) {
       # Unreadable owner file: fall through and behave as before.
     }
   }
-  Write-Output "restart.ps1: stopping gateway (PID $oldPid, port $port)"
+  Write-Status "restart.ps1: stopping gateway (PID $oldPid, port $port)"
   Stop-Process -Id $oldPid -Force
   for ($i = 0; $i -lt 20; $i += 1) {
     Start-Sleep -Milliseconds 250
     if (-not (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)) { break }
   }
 } else {
-  Write-Output "restart.ps1: no gateway on port $port; starting fresh"
+  Write-Status "restart.ps1: no gateway on port $port; starting fresh"
 }
 
-$logDir = Join-Path $env:TEMP "modeldock"
-New-Item -ItemType Directory -Force -Path $logDir | Out-Null
-$stdout = Join-Path $logDir "gateway.log"
-$stderr = Join-Path $logDir "gateway.err.log"
+$log = Join-Path $root "modeldock.log"
+
+# The old gateway's stdout/stderr handles can linger for a moment after
+# Stop-Process. Wait for the log to become writable BEFORE rotating: an
+# in-place Move-Item on a still-locked file fails, and that failure used to
+# abort the restart. If it stays locked, fall back to a per-run log file so
+# the redirect never races the dying process's file handles.
+function Test-WritableFile($file) {
+  try {
+    $probe = [System.IO.File]::Open($file, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    $probe.Close()
+    return $true
+  } catch {
+    return $false
+  }
+}
+$logsReady = $false
+for ($i = 0; $i -lt 20; $i += 1) {
+  if (Test-WritableFile $log) {
+    $logsReady = $true
+    break
+  }
+  Start-Sleep -Milliseconds 250
+}
+if (-not $logsReady) {
+  $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $log = Join-Path $root "modeldock-$stamp.log"
+  Write-Status "WARNING: modeldock.log was still locked; using per-run log ($log)"
+} elseif ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  # Rotate at startup, one previous generation (same policy as start-hidden.ps1):
+  # the log is append-only for the life of the process, so a cap on growth can
+  # only be applied between runs. 32 MB keeps roughly a month of daily use.
+  try {
+    Move-Item -LiteralPath $log -Destination "$log.1" -Force
+  } catch {
+    # Rotation is best-effort now that the lock wait passed; a raced lock must
+    # not turn a restart into a failure.
+    Write-Status "WARNING: could not rotate modeldock.log: $($_.Exception.Message)"
+  }
+}
 
 # Prefer an explicit path, then a bundled Node under <root>\node (the installer
 # downloads Node 22 LTS there when none is on PATH), then PATH.
@@ -333,7 +384,7 @@ if (-not $nodeExe) {
 }
 if (-not $nodeExe) { $nodeExe = (Get-Command node -ErrorAction SilentlyContinue).Source }
 if (-not $nodeExe) {
-  Write-Output "ERROR: node.exe not found; install Node 22+ or re-run the ModelDock installer"
+  Write-Status "ERROR: node.exe not found; install Node 22+ or re-run the ModelDock installer"
   exit 1
 }
 
@@ -343,27 +394,41 @@ if (-not $nodeExe) {
 $server = Join-Path $root "src\server.mjs"
 if (-not (Test-Path -LiteralPath $server)) { $server = Join-Path $root "dist\modeldock.mjs" }
 
-# Quote the script path so an install dir with a space is not split into two argv entries.
-Start-Process -FilePath $nodeExe -ArgumentList "`"$server`"" -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
-Write-Output "restart.ps1: started gateway from $root (logs: $logDir)"
+try {
+  # Quote both paths: an installed layout under a home dir with a space
+  # (e.g. "C:\Users\Chen Bao\.modeldock") would otherwise be split by node's
+  # CRT into two argv entries and fail with "Cannot find module". cmd.exe does
+  # the >> redirection so stdout and stderr share the same log file as the
+  # start-hidden launcher (and the "check modeldock.log" guidance).
+  Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden
+} catch {
+  Write-Status "ERROR: failed to start gateway: $($_.Exception.Message)"
+  exit 1
+}
+Write-Status "restart.ps1: started gateway from $root (logs: $log)"
 
 for ($i = 0; $i -lt 40; $i += 1) {
   Start-Sleep -Milliseconds 250
   try {
     Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2 -UseBasicParsing | Out-Null
-    Write-Output "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    Write-Status "restart.ps1: gateway healthy at http://127.0.0.1:$port"
     exit 0
   } catch {
+    # A returned HTTP status (e.g. 503 before a token is configured) still proves
+    # the gateway is up and listening - only a connection failure means it is not.
     if ($_.Exception.Response) {
-      Write-Output "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
+      Write-Status "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
       exit 0
     }
-    # Otherwise still booting; keep polling.
+    # Otherwise still booting / connection refused; keep polling.
   }
 }
 
-Write-Output "ERROR: gateway did not become healthy within 10s"
-if (Test-Path $stderr) { Get-Content $stderr -Tail 10 -ErrorAction SilentlyContinue }
+Write-Status "ERROR: gateway did not become healthy within 10s"
+if (Test-Path $log) {
+  $tail = Get-Content $log -Tail 10 -ErrorAction SilentlyContinue
+  if ($tail) { $tail | ForEach-Object { [Console]::Error.WriteLine($_) } }
+}
 exit 1
 EOF
 
@@ -409,13 +474,23 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 find_listener_pid() {
+  pid=""
   if command -v lsof >/dev/null 2>&1; then
-    lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
-  elif command -v fuser >/dev/null 2>&1; then
-    fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true
-  else
-    true
+    pid="$(lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true)"
+    if [ -n "$pid" ]; then printf '%s\n' "$pid"; return; fi
   fi
+  if command -v ss >/dev/null 2>&1; then
+    # Minimal Linux images (Debian/Ubuntu containers) ship neither lsof nor
+    # psmisc, but do ship ss. Without this branch the old PID is never found and
+    # the new gateway dies with EADDRINUSE while the stale one keeps answering.
+    pid="$(ss -tlnpH "sport = :$PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -n 1 | cut -d= -f2 || true)"
+    if [ -n "$pid" ]; then printf '%s\n' "$pid"; return; fi
+  fi
+  if command -v fuser >/dev/null 2>&1; then
+    pid="$(fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true)"
+    if [ -n "$pid" ]; then printf '%s\n' "$pid"; return; fi
+  fi
+  true
 }
 
 resolve_node() {
@@ -458,6 +533,11 @@ if [ ! -f "$SERVER" ]; then
 fi
 
 OLD_PID="$(find_listener_pid)"
+if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null \
+    && [ -z "$OLD_PID" ]; then
+  status "ERROR: port $PORT is active but its listener PID could not be identified; refusing a fake restart"
+  exit 3
+fi
 
 check_owner() {
   [ -n "$OLD_PID" ] || return 0
@@ -495,7 +575,9 @@ wait_for_health() {
   old_pid="${1:-}"
   i=0
   while [ "$i" -lt 40 ]; do
-    # No -f: a 503 (up but awaiting a token) still proves the process is listening.
+    # No -f: a 503 (gateway up but no token yet) still proves the process is
+    # listening. -f would treat that as a failure and loop until the timeout,
+    # reporting a healthy fresh install as "did not start".
     if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
       new_pid="$(find_listener_pid)"
       if [ -z "$old_pid" ] || [ -z "$new_pid" ] || [ "$new_pid" != "$old_pid" ]; then
@@ -558,6 +640,7 @@ if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 33554432 ]; then
 fi
 
 nohup "$NODE_BIN" "$SERVER" >>"$LOG" 2>&1 &
+NEW_PID=$!
 status "restart.sh: started gateway from $ROOT (logs: $LOG)"
 
 if wait_for_health "$OLD_PID"; then
@@ -565,6 +648,8 @@ if wait_for_health "$OLD_PID"; then
 fi
 
 status "ERROR: gateway did not become healthy within 10s"
+kill "$NEW_PID" 2>/dev/null || true
+wait "$NEW_PID" 2>/dev/null || true
 if [ -f "$LOG" ]; then
   tail -n 10 "$LOG" >&2 || true
 fi
@@ -576,94 +661,162 @@ chmod +x "$RESTART_SH"
 RECOVER="$ROOT/scripts/recover.sh"
 cat > "$RECOVER" <<'EOF'
 #!/bin/sh
+# ModelDock manual recovery menu.
+# Choose gateway restart, restore the last native Codex configuration, or repair
+# the start-at-login entry.
 set -eu
+
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 STATE_DIR="${MODELDOCK_STATE_DIR:-$ROOT}"
 PORT="${MODELDOCK_PORT:-4097}"
 if [ -f "$ROOT/.env" ]; then
-  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1)"
-  [ -n "$ENV_PORT" ] && PORT="$ENV_PORT"
+  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1 | tr -d '\r' || true)"
+  case "$ENV_PORT" in
+    ''|*[!0-9]*) ;;
+    *) [ "$ENV_PORT" -gt 0 ] && PORT="$ENV_PORT" ;;
+  esac
 fi
-restart_gateway() {
-  if [ ! -x "$ROOT/scripts/start-hidden.sh" ]; then
-    echo "start-hidden.sh is missing from $ROOT" >&2
-    exit 1
+
+# Resolve a Node binary the same bundled-first way as restart.sh. A self-contained
+# install (node auto-downloaded into "$ROOT/node" because the machine had none)
+# has no node on PATH, so a bare "node" here would fail the config restore exactly
+# when the gateway is down and recovery matters most.
+resolve_node() {
+  if [ -n "${MODELDOCK_NODE_PATH:-}" ] && [ -x "$MODELDOCK_NODE_PATH" ]; then
+    printf '%s\n' "$MODELDOCK_NODE_PATH"; return
   fi
-  old_pid=""
-  has_lsof=0
-  if command -v lsof >/dev/null 2>&1; then has_lsof=1; fi
-  if [ "$has_lsof" -eq 1 ]; then
-    pid="$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)"
-    if [ -n "$pid" ]; then
-      command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-      case "$command" in
-        *"$ROOT"*) old_pid="$pid"; kill "$pid";;
-        *) echo "Refusing to stop an unrelated process on port $PORT." >&2; exit 1;;
-      esac
+  best_bin=""; best_v=""
+  for d in "$ROOT"/node/v*; do
+    [ -d "$d" ] && [ -x "$d/bin/node" ] || continue
+    v="$(basename "$d" | sed 's/^v//')"
+    if [ -z "$best_v" ] || [ "$(printf '%s\n%s\n' "$v" "$best_v" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1)" = "$v" ]; then
+      best_bin="$d/bin/node"; best_v="$v"
     fi
-  fi
-  # Give the old process and its socket time to release before starting the
-  # replacement, so the new instance cannot fail with EADDRINUSE and the health
-  # probe below cannot be answered by the dying process (false healthy).
-  i=0
-  while [ "$i" -lt 20 ]; do
-    alive=""
-    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then alive=1; fi
-    listening=""
-    if [ "$has_lsof" -eq 1 ] && [ -n "$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)" ]; then listening=1; fi
-    if [ -z "$alive" ] && [ -z "$listening" ]; then break; fi
-    sleep 0.25
-    i=$((i + 1))
   done
-  if [ "$i" -ge 20 ]; then
-    echo "Port $PORT did not release within 5s; aborting restart." >&2
-    exit 1
-  fi
-  "$ROOT/scripts/start-hidden.sh"
-  i=0
-  while [ "$i" -lt 40 ]; do
-    # No -f: a 503 before a token is set still proves the gateway is listening.
-    if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
-      if [ "$has_lsof" -eq 1 ]; then
-        new_pid="$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)"
-        if [ -n "$new_pid" ] && [ "$new_pid" != "$old_pid" ]; then
-          echo "ModelDock gateway is healthy at http://127.0.0.1:$PORT (PID $new_pid)"; return
-        fi
-      else
-        echo "ModelDock gateway is healthy at http://127.0.0.1:$PORT"; return
-      fi
-    fi
-    sleep 0.25; i=$((i + 1))
-  done
-  echo "Gateway did not become healthy. Check $ROOT/modeldock.log" >&2; exit 1
+  if [ -n "$best_bin" ]; then printf '%s\n' "$best_bin"; return; fi
+  command -v node || true
 }
+
+restore_previous_update() {
+  marker="$ROOT/.modeldock-rollback/current"
+  [ -f "$marker" ] || return 1
+  node_bin="$(resolve_node)"
+  [ -n "$node_bin" ] && [ -x "$node_bin" ] || return 1
+  "$node_bin" --input-type=module - "$ROOT" "$marker" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+
+const [rootArg, marker] = process.argv.slice(2);
+const root = path.resolve(rootArg);
+const rollbackRoot = path.join(root, ".modeldock-rollback");
+const name = fs.readFileSync(marker, "utf8").trim();
+if (!name || path.basename(name) !== name) throw new Error("invalid update rollback marker");
+const rollbackDir = path.join(rollbackRoot, name);
+const manifest = JSON.parse(fs.readFileSync(path.join(rollbackDir, "manifest.json"), "utf8"));
+const prepared = [];
+let applied = 0;
+const remove = (file) => { try { fs.unlinkSync(file); } catch (error) { if (error.code !== "ENOENT") throw error; } };
+try {
+  for (const entry of manifest.files || []) {
+    const target = path.resolve(root, entry.path);
+    if (target !== root && !target.startsWith(`${root}${path.sep}`)) throw new Error(`rollback path escaped install root: ${entry.path}`);
+    const stage = `${target}.rollback-stage-${process.pid}`;
+    const current = `${target}.rollback-current-${process.pid}`;
+    remove(stage);
+    remove(current);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const currentExisted = fs.existsSync(target);
+    if (currentExisted) fs.copyFileSync(target, current);
+    if (entry.existed) {
+      const source = path.resolve(rollbackDir, entry.path);
+      if (!source.startsWith(`${rollbackDir}${path.sep}`) || !fs.statSync(source).isFile()) throw new Error(`rollback file is missing: ${entry.path}`);
+      fs.copyFileSync(source, stage);
+    }
+    prepared.push({ target, stage, current, currentExisted, restore: Boolean(entry.existed) });
+  }
+  for (const item of prepared) {
+    if (item.restore) fs.renameSync(item.stage, item.target);
+    else remove(item.target);
+    applied += 1;
+  }
+} catch (error) {
+  for (let index = applied - 1; index >= 0; index -= 1) {
+    const item = prepared[index];
+    if (item.currentExisted) fs.copyFileSync(item.current, item.target);
+    else remove(item.target);
+  }
+  throw error;
+} finally {
+  for (const item of prepared) {
+    try { remove(item.stage); } catch {}
+    try { remove(item.current); } catch {}
+  }
+}
+NODE
+}
+
+restart_gateway() {
+  restart="$ROOT/scripts/restart.sh"
+  if [ ! -x "$restart" ]; then
+    echo "restart.sh is missing from $ROOT" >&2
+    exit 1
+  fi
+  if "$restart"; then return; else restart_status=$?; fi
+  # Codes 2 and 3 are ownership/PID-safety refusals, not a bad release. Never
+  # replace files while a listener we cannot safely stop may still be running.
+  if [ "$restart_status" -eq 2 ] || [ "$restart_status" -eq 3 ]; then exit "$restart_status"; fi
+  echo "New installed version did not become healthy; restoring the complete previous version set." >&2
+  if restore_previous_update && "$ROOT/scripts/restart.sh"; then
+    echo "Rolled back the complete installed version; gateway is healthy."
+    return
+  fi
+  echo "Gateway did not become healthy. Check $ROOT/modeldock.log" >&2
+  exit 1
+}
+
 restore_native() {
   if curl -fsS --max-time 3 -X POST "http://127.0.0.1:$PORT/api/config/disable" >/dev/null 2>&1; then
-    echo "Codex native route restored through the running gateway."; return
+    echo "Codex native route restored through the running gateway."
+    return
   fi
   echo "Gateway is unavailable; restoring from the local backup."
   CODEX_HOME_VALUE="${MODELDOCK_CODEX_HOME:-${CODEX_HOME:-$HOME/.codex}}"
   STATE="$CODEX_HOME_VALUE/modeldock/config-switch-state.json"
   CONFIG="$CODEX_HOME_VALUE/config.toml"
-  [ -f "$STATE" ] || { echo "ModelDock switch state was not found: $STATE" >&2; exit 1; }
-  node --input-type=module - "$STATE" "$CONFIG" <<'NODE'
+  if [ ! -f "$STATE" ]; then
+    echo "ModelDock switch state was not found: $STATE" >&2
+    exit 1
+  fi
+  NODE_BIN="$(resolve_node)"
+  if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then
+    echo "node not found; cannot restore the Codex config. Install Node 22+ or re-run the installer." >&2
+    exit 1
+  fi
+  "$NODE_BIN" --input-type=module - "$STATE" "$CONFIG" <<'NODE'
 import { copyFile, readFile, rm, writeFile, rename } from "node:fs/promises";
 import path from "node:path";
 const [statePath, configPath] = process.argv.slice(2);
 const state = JSON.parse(await readFile(statePath, "utf8"));
-if (!state.enabled) { console.log("Codex is already on the native route."); process.exit(0); }
+if (!state.enabled) {
+  console.log("Codex is already on the native route.");
+  process.exit(0);
+}
 if (!state.backupPath) throw new Error("ModelDock backup path is missing.");
 const backup = path.resolve(state.backupPath);
-await readFile(backup);
+try { await readFile(backup); } catch { throw new Error(`ModelDock backup is missing: ${backup}`); }
 try {
   await readFile(configPath);
   await copyFile(configPath, `${configPath}.native-recovery-${Date.now()}.bak`);
-  if (state.originalExisted) await copyFile(backup, configPath); else await rm(configPath, { force: true });
+  if (state.originalExisted) await copyFile(backup, configPath);
+  else await rm(configPath, { force: true });
 } catch (error) {
   if (error.code === "ENOENT" && state.originalExisted) await copyFile(backup, configPath);
   else if (error.code !== "ENOENT") throw error;
 }
-state.enabled = false; state.restartRequired = true; state.lastBackupPath = backup; state.changedAt = new Date().toISOString();
+state.enabled = false;
+state.restartRequired = true;
+state.lastBackupPath = backup;
+state.changedAt = new Date().toISOString();
 const temporary = `${statePath}.${process.pid}.tmp`;
 await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
 await rename(temporary, statePath);
@@ -671,6 +824,7 @@ console.log(`Codex native route restored from ${backup}`);
 console.log("Fully quit and restart Codex.");
 NODE
 }
+
 repair_autostart() {
   if [ "$(uname -s)" != "Darwin" ] && [ "${MODELDOCK_FAKE_DARWIN:-}" != "1" ]; then
     echo "Start-at-login repair is macOS-only; on Windows use the installer's recover menu." >&2
@@ -699,6 +853,15 @@ repair_autostart() {
   PLIST_DIR="${MODELDOCK_AUTOSTART_PLIST_DIR:-$HOME/Library/LaunchAgents}"
   PLIST="$PLIST_DIR/com.modeldock.gateway.plist"
   mkdir -p "$PLIST_DIR"
+  # plist is XML: a user path containing & < > would otherwise break launchd.
+  xml_escape() {
+    printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+  }
+  NODE_DIR="$(dirname "$NODE_BIN")"
+  PLIST_PATH="$(xml_escape "$NODE_DIR:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")"
+  PLIST_NODE="$(xml_escape "$NODE_BIN")"
+  PLIST_SERVER="$(xml_escape "$SERVER")"
+  PLIST_ROOT="$(xml_escape "$ROOT")"
   cat > "$PLIST" <<PLISTEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -707,20 +870,20 @@ repair_autostart() {
   <key>Label</key><string>com.modeldock.gateway</string>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>PATH</key><string>$(dirname "$NODE_BIN"):/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>MODELDOCK_NODE_PATH</key><string>$NODE_BIN</string>
+    <key>PATH</key><string>$PLIST_PATH</string>
+    <key>MODELDOCK_NODE_PATH</key><string>$PLIST_NODE</string>
   </dict>
   <key>ProgramArguments</key>
   <array>
-    <string>$NODE_BIN</string>
-    <string>$SERVER</string>
+    <string>$PLIST_NODE</string>
+    <string>$PLIST_SERVER</string>
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>10</integer>
-  <key>WorkingDirectory</key><string>$ROOT</string>
-  <key>StandardOutPath</key><string>$ROOT/modeldock.log</string>
-  <key>StandardErrorPath</key><string>$ROOT/modeldock.log</string>
+  <key>WorkingDirectory</key><string>$PLIST_ROOT</string>
+  <key>StandardOutPath</key><string>$PLIST_ROOT/modeldock.log</string>
+  <key>StandardErrorPath</key><string>$PLIST_ROOT/modeldock.log</string>
 </dict>
 </plist>
 PLISTEOF
@@ -732,6 +895,8 @@ PLISTEOF
     exit 1
   fi
 }
+
+echo ""
 echo "ModelDock manual recovery"
 echo "1. Restart ModelDock gateway"
 echo "2. Restore Codex native route"
@@ -739,7 +904,13 @@ echo "3. Repair start-at-login"
 echo "Q. Quit"
 printf "Choose 1, 2, 3, or Q: "
 read -r choice
-case "$choice" in 1) restart_gateway ;; 2) restore_native ;; 3) repair_autostart ;; q|Q|"") exit 0 ;; *) echo "Unknown choice: $choice" >&2; exit 1 ;; esac
+case "$choice" in
+  1) restart_gateway ;;
+  2) restore_native ;;
+  3) repair_autostart ;;
+  q|Q|"") exit 0 ;;
+  *) echo "Unknown choice: $choice" >&2; exit 1 ;;
+esac
 EOF
 chmod +x "$RECOVER"
 

--- a/scripts/recover.ps1
+++ b/scripts/recover.ps1
@@ -86,12 +86,19 @@ function Restore-Native {
   } elseif ($state.originalExisted) {
     Copy-Item -LiteralPath $backup -Destination $config -Force
   }
-  $state.enabled = $false
-  $state.restartRequired = $true
-  $state.lastBackupPath = $backup
-  $state.changedAt = (Get-Date).ToUniversalTime().ToString("o")
+  # Rebuild the state as a fresh ordered map: Windows PowerShell 5.1 throws when a
+  # property that ConvertFrom-Json did not create (here lastBackupPath) is set via
+  # dot assignment, so copy the existing keys and override the ones we change.
+  $out = [ordered]@{}
+  foreach ($p in $state.PSObject.Properties) { $out[$p.Name] = $p.Value }
+  $out['enabled'] = $false
+  $out['restartRequired'] = $true
+  $out['lastBackupPath'] = $backup
+  $out['changedAt'] = (Get-Date).ToUniversalTime().ToString("o")
   $tmp = "$statePath.$PID.tmp"
-  $state | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $tmp -Encoding utf8
+  # Write UTF-8 without a BOM: the gateway reads this file with Node's utf8 and a
+  # BOM would make JSON.parse fail (Set-Content -Encoding utf8 emits a BOM on 5.1).
+  [System.IO.File]::WriteAllText($tmp, ($out | ConvertTo-Json -Depth 10), (New-Object System.Text.UTF8Encoding($false)))
   Move-Item -LiteralPath $tmp -Destination $statePath -Force
   Write-Output "Codex native route restored from $backup"
   Write-Output "Fully quit and restart Codex."

--- a/scripts/recover.ps1
+++ b/scripts/recover.ps1
@@ -54,7 +54,20 @@ function Restart-Gateway {
     throw "restart.ps1 is missing from $root"
   }
   & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
-  if ($LASTEXITCODE -ne 0) { throw "gateway restart failed" }
+  if ($LASTEXITCODE -ne 0) {
+    # Roll back a bad self-update: if the new bundle never became healthy and the
+    # updater kept the previous one, restore it and restart once more so a broken
+    # release does not leave the gateway dead (and Codex routed at it).
+    $bundle = Join-Path $root "dist\modeldock.mjs"
+    $prev = "$bundle.prev"
+    if ((Test-Path -LiteralPath $prev) -and (Test-Path -LiteralPath $bundle)) {
+      Write-Output "New bundle did not become healthy; rolling back to the previous version."
+      Copy-Item -LiteralPath $prev -Destination $bundle -Force
+      & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
+      if ($LASTEXITCODE -eq 0) { return }
+    }
+    throw "gateway restart failed"
+  }
 }
 
 function Restore-Native {

--- a/scripts/recover.ps1
+++ b/scripts/recover.ps1
@@ -51,6 +51,70 @@ function Repair-Autostart {
   } finally { if ($runKey) { $runKey.Close() } }
 }
 
+function Restore-PreviousUpdate {
+  $rollbackRoot = Join-Path $root ".modeldock-rollback"
+  $marker = Join-Path $rollbackRoot "current"
+  if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) { return $false }
+  $name = [System.IO.File]::ReadAllText($marker).Trim()
+  if (-not $name -or [System.IO.Path]::GetFileName($name) -ne $name) { throw "invalid update rollback marker" }
+  $rollbackDir = Join-Path $rollbackRoot $name
+  $manifestPath = Join-Path $rollbackDir "manifest.json"
+  $manifest = [System.IO.File]::ReadAllText($manifestPath) | ConvertFrom-Json
+  $rootPrefix = [System.IO.Path]::GetFullPath($root).TrimEnd('\') + '\'
+  $rollbackPrefix = [System.IO.Path]::GetFullPath($rollbackDir).TrimEnd('\') + '\'
+  $prepared = @()
+  $applied = 0
+  try {
+    foreach ($entry in $manifest.files) {
+      $relative = ([string]$entry.path).Replace('/', '\')
+      $target = [System.IO.Path]::GetFullPath((Join-Path $root $relative))
+      if (-not $target.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "rollback path escaped install root: $relative"
+      }
+      $stage = "$target.rollback-stage-$PID"
+      $current = "$target.rollback-current-$PID"
+      Remove-Item -LiteralPath $stage, $current -Force -ErrorAction SilentlyContinue
+      [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($target)) | Out-Null
+      $currentExisted = Test-Path -LiteralPath $target -PathType Leaf
+      if ($currentExisted) { Copy-Item -LiteralPath $target -Destination $current -Force }
+      $restore = [bool]$entry.existed
+      if ($restore) {
+        $source = [System.IO.Path]::GetFullPath((Join-Path $rollbackDir $relative))
+        if (-not $source.StartsWith($rollbackPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not (Test-Path -LiteralPath $source -PathType Leaf)) {
+          throw "rollback file is missing: $relative"
+        }
+        Copy-Item -LiteralPath $source -Destination $stage -Force
+      }
+      $prepared += [pscustomobject]@{ Target = $target; Stage = $stage; Current = $current; CurrentExisted = $currentExisted; Restore = $restore }
+    }
+    foreach ($item in $prepared) {
+      if ($item.Restore) {
+        if (Test-Path -LiteralPath $item.Target -PathType Leaf) {
+          [System.IO.File]::Replace($item.Stage, $item.Target, $null)
+        } else {
+          Move-Item -LiteralPath $item.Stage -Destination $item.Target
+        }
+      } elseif (Test-Path -LiteralPath $item.Target) {
+        Remove-Item -LiteralPath $item.Target -Force
+      }
+      $applied += 1
+    }
+  } catch {
+    for ($index = $applied - 1; $index -ge 0; $index -= 1) {
+      $item = $prepared[$index]
+      if ($item.CurrentExisted) { Copy-Item -LiteralPath $item.Current -Destination $item.Target -Force }
+      else { Remove-Item -LiteralPath $item.Target -Force -ErrorAction SilentlyContinue }
+    }
+    throw
+  } finally {
+    foreach ($item in $prepared) {
+      Remove-Item -LiteralPath $item.Stage, $item.Current -Force -ErrorAction SilentlyContinue
+    }
+  }
+  return $true
+}
+
 function Restart-Gateway {
   Repair-Autostart
   $restart = Join-Path $root "scripts\restart.ps1"
@@ -59,14 +123,10 @@ function Restart-Gateway {
   }
   & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
   if ($LASTEXITCODE -ne 0) {
-    # Roll back a bad self-update: if the new bundle never became healthy and the
-    # updater kept the previous one, restore it and restart once more so a broken
-    # release does not leave the gateway dead (and Codex routed at it).
-    $bundle = Join-Path $root "dist\modeldock.mjs"
-    $prev = "$bundle.prev"
-    if ((Test-Path -LiteralPath $prev) -and (Test-Path -LiteralPath $bundle)) {
-      Write-Output "New bundle did not become healthy; rolling back to the previous version."
-      Copy-Item -LiteralPath $prev -Destination $bundle -Force
+    # A bundle and its bridge/lifecycle helpers are one versioned unit. Restore
+    # the complete snapshot transactionally before retrying the old restart.
+    if (Restore-PreviousUpdate) {
+      Write-Output "New installed version did not become healthy; restored the complete previous version set."
       & powershell -NoProfile -ExecutionPolicy Bypass -File $restart
       if ($LASTEXITCODE -eq 0) { return }
     }

--- a/scripts/recover.ps1
+++ b/scripts/recover.ps1
@@ -13,10 +13,14 @@ if (Test-Path -LiteralPath $envFile) {
   }
 }
 
-# Start-at-login repair: when the autostart decision mark exists but the Run key
-# is gone (registry cleanup, earlier toggle-off that deleted the key), re-write
-# the login entry before restarting the gateway. A missing mark means no decision
-# was ever recorded, so an explicit off is never silently overridden.
+# Start-at-login repair: when a start-at-login decision was recorded (the mark
+# exists) but the Run key is gone - registry cleanup, or an earlier toggle-off that
+# deleted the key - re-write the login entry before restarting the gateway.
+# By design autostart is a re-asserted default: the gateway re-enables it on every
+# version change (see initAutostartDefault), and this repair restores it on every
+# recover run as well. A toggle-off is therefore NOT permanent across a recover or
+# an update - to keep it off, turn it off again afterward. Only a missing mark (no
+# decision ever recorded) is left untouched.
 $autostartKeyName = if ($env:MODELDOCK_AUTOSTART_KEY) { $env:MODELDOCK_AUTOSTART_KEY } else { "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" }
 $autostartValueName = if ($env:MODELDOCK_AUTOSTART_NAME) { $env:MODELDOCK_AUTOSTART_NAME } else { "ModelDock" }
 $autostartStateDir = if ($env:MODELDOCK_STATE_DIR) { $env:MODELDOCK_STATE_DIR } else { $root }

--- a/scripts/recover.sh
+++ b/scripts/recover.sh
@@ -12,6 +12,26 @@ if [ -f "$ROOT/.env" ]; then
   [ -n "$ENV_PORT" ] && PORT="$ENV_PORT"
 fi
 
+# Resolve a Node binary the same bundled-first way as restart.sh. A self-contained
+# install (node auto-downloaded into "$ROOT/node" because the machine had none)
+# has no node on PATH, so a bare "node" here would fail the config restore exactly
+# when the gateway is down and recovery matters most.
+resolve_node() {
+  if [ -n "${MODELDOCK_NODE_PATH:-}" ] && [ -x "$MODELDOCK_NODE_PATH" ]; then
+    printf '%s\n' "$MODELDOCK_NODE_PATH"; return
+  fi
+  best_bin=""; best_v=""
+  for d in "$ROOT"/node/v*; do
+    [ -d "$d" ] && [ -x "$d/bin/node" ] || continue
+    v="$(basename "$d" | sed 's/^v//')"
+    if [ -z "$best_v" ] || [ "$(printf '%s\n%s\n' "$v" "$best_v" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1)" = "$v" ]; then
+      best_bin="$d/bin/node"; best_v="$v"
+    fi
+  done
+  if [ -n "$best_bin" ]; then printf '%s\n' "$best_bin"; return; fi
+  command -v node || true
+}
+
 restart_gateway() {
   if [ ! -x "$ROOT/scripts/start-hidden.sh" ]; then
     echo "start-hidden.sh is missing from $ROOT" >&2
@@ -83,7 +103,12 @@ restore_native() {
     echo "ModelDock switch state was not found: $STATE" >&2
     exit 1
   fi
-  node --input-type=module - "$STATE" "$CONFIG" <<'NODE'
+  NODE_BIN="$(resolve_node)"
+  if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then
+    echo "node not found; cannot restore the Codex config. Install Node 22+ or re-run the installer." >&2
+    exit 1
+  fi
+  "$NODE_BIN" --input-type=module - "$STATE" "$CONFIG" <<'NODE'
 import { copyFile, readFile, rm, writeFile, rename } from "node:fs/promises";
 import path from "node:path";
 const [statePath, configPath] = process.argv.slice(2);
@@ -144,6 +169,15 @@ repair_autostart() {
   PLIST_DIR="${MODELDOCK_AUTOSTART_PLIST_DIR:-$HOME/Library/LaunchAgents}"
   PLIST="$PLIST_DIR/com.modeldock.gateway.plist"
   mkdir -p "$PLIST_DIR"
+  # plist is XML: a user path containing & < > would otherwise break launchd.
+  xml_escape() {
+    printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+  }
+  NODE_DIR="$(dirname "$NODE_BIN")"
+  PLIST_PATH="$(xml_escape "$NODE_DIR:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")"
+  PLIST_NODE="$(xml_escape "$NODE_BIN")"
+  PLIST_SERVER="$(xml_escape "$SERVER")"
+  PLIST_ROOT="$(xml_escape "$ROOT")"
   cat > "$PLIST" <<PLISTEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -152,20 +186,20 @@ repair_autostart() {
   <key>Label</key><string>com.modeldock.gateway</string>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>PATH</key><string>$(dirname "$NODE_BIN"):/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    <key>MODELDOCK_NODE_PATH</key><string>$NODE_BIN</string>
+    <key>PATH</key><string>$PLIST_PATH</string>
+    <key>MODELDOCK_NODE_PATH</key><string>$PLIST_NODE</string>
   </dict>
   <key>ProgramArguments</key>
   <array>
-    <string>$NODE_BIN</string>
-    <string>$SERVER</string>
+    <string>$PLIST_NODE</string>
+    <string>$PLIST_SERVER</string>
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>10</integer>
-  <key>WorkingDirectory</key><string>$ROOT</string>
-  <key>StandardOutPath</key><string>$ROOT/modeldock.log</string>
-  <key>StandardErrorPath</key><string>$ROOT/modeldock.log</string>
+  <key>WorkingDirectory</key><string>$PLIST_ROOT</string>
+  <key>StandardOutPath</key><string>$PLIST_ROOT/modeldock.log</string>
+  <key>StandardErrorPath</key><string>$PLIST_ROOT/modeldock.log</string>
 </dict>
 </plist>
 PLISTEOF

--- a/scripts/recover.sh
+++ b/scripts/recover.sh
@@ -50,7 +50,8 @@ restart_gateway() {
   "$ROOT/scripts/start-hidden.sh"
   i=0
   while [ "$i" -lt 40 ]; do
-    if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    # No -f: a 503 before a token is set still proves the gateway is listening.
+    if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
       if [ "$has_lsof" -eq 1 ]; then
         new_pid="$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)"
         if [ -n "$new_pid" ] && [ "$new_pid" != "$old_pid" ]; then

--- a/scripts/recover.sh
+++ b/scripts/recover.sh
@@ -8,8 +8,11 @@ ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 STATE_DIR="${MODELDOCK_STATE_DIR:-$ROOT}"
 PORT="${MODELDOCK_PORT:-4097}"
 if [ -f "$ROOT/.env" ]; then
-  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1)"
-  [ -n "$ENV_PORT" ] && PORT="$ENV_PORT"
+  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1 | tr -d '\r' || true)"
+  case "$ENV_PORT" in
+    ''|*[!0-9]*) ;;
+    *) [ "$ENV_PORT" -gt 0 ] && PORT="$ENV_PORT" ;;
+  esac
 fi
 
 # Resolve a Node binary the same bundled-first way as restart.sh. A self-contained
@@ -32,77 +35,78 @@ resolve_node() {
   command -v node || true
 }
 
+restore_previous_update() {
+  marker="$ROOT/.modeldock-rollback/current"
+  [ -f "$marker" ] || return 1
+  node_bin="$(resolve_node)"
+  [ -n "$node_bin" ] && [ -x "$node_bin" ] || return 1
+  "$node_bin" --input-type=module - "$ROOT" "$marker" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+
+const [rootArg, marker] = process.argv.slice(2);
+const root = path.resolve(rootArg);
+const rollbackRoot = path.join(root, ".modeldock-rollback");
+const name = fs.readFileSync(marker, "utf8").trim();
+if (!name || path.basename(name) !== name) throw new Error("invalid update rollback marker");
+const rollbackDir = path.join(rollbackRoot, name);
+const manifest = JSON.parse(fs.readFileSync(path.join(rollbackDir, "manifest.json"), "utf8"));
+const prepared = [];
+let applied = 0;
+const remove = (file) => { try { fs.unlinkSync(file); } catch (error) { if (error.code !== "ENOENT") throw error; } };
+try {
+  for (const entry of manifest.files || []) {
+    const target = path.resolve(root, entry.path);
+    if (target !== root && !target.startsWith(`${root}${path.sep}`)) throw new Error(`rollback path escaped install root: ${entry.path}`);
+    const stage = `${target}.rollback-stage-${process.pid}`;
+    const current = `${target}.rollback-current-${process.pid}`;
+    remove(stage);
+    remove(current);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const currentExisted = fs.existsSync(target);
+    if (currentExisted) fs.copyFileSync(target, current);
+    if (entry.existed) {
+      const source = path.resolve(rollbackDir, entry.path);
+      if (!source.startsWith(`${rollbackDir}${path.sep}`) || !fs.statSync(source).isFile()) throw new Error(`rollback file is missing: ${entry.path}`);
+      fs.copyFileSync(source, stage);
+    }
+    prepared.push({ target, stage, current, currentExisted, restore: Boolean(entry.existed) });
+  }
+  for (const item of prepared) {
+    if (item.restore) fs.renameSync(item.stage, item.target);
+    else remove(item.target);
+    applied += 1;
+  }
+} catch (error) {
+  for (let index = applied - 1; index >= 0; index -= 1) {
+    const item = prepared[index];
+    if (item.currentExisted) fs.copyFileSync(item.current, item.target);
+    else remove(item.target);
+  }
+  throw error;
+} finally {
+  for (const item of prepared) {
+    try { remove(item.stage); } catch {}
+    try { remove(item.current); } catch {}
+  }
+}
+NODE
+}
+
 restart_gateway() {
-  if [ ! -x "$ROOT/scripts/start-hidden.sh" ]; then
-    echo "start-hidden.sh is missing from $ROOT" >&2
+  restart="$ROOT/scripts/restart.sh"
+  if [ ! -x "$restart" ]; then
+    echo "restart.sh is missing from $ROOT" >&2
     exit 1
   fi
-  old_pid=""
-  has_lsof=0
-  if command -v lsof >/dev/null 2>&1; then has_lsof=1; fi
-  if [ "$has_lsof" -eq 1 ]; then
-    pid="$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)"
-    if [ -n "$pid" ]; then
-      command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-      case "$command" in
-        *"$ROOT"*) old_pid="$pid"; kill "$pid";;
-        *) echo "Refusing to stop an unrelated process on port $PORT." >&2; exit 1;;
-      esac
-    fi
-  fi
-  # Give the old process and its socket time to release before starting the
-  # replacement, so the new instance cannot fail with EADDRINUSE and the health
-  # probe below cannot be answered by the dying process (false healthy).
-  i=0
-  while [ "$i" -lt 20 ]; do
-    alive=""
-    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then alive=1; fi
-    listening=""
-    if [ "$has_lsof" -eq 1 ] && [ -n "$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)" ]; then listening=1; fi
-    if [ -z "$alive" ] && [ -z "$listening" ]; then break; fi
-    sleep 0.25
-    i=$((i + 1))
-  done
-  if [ "$i" -ge 20 ]; then
-    echo "Port $PORT did not release within 5s; aborting restart." >&2
-    exit 1
-  fi
-  "$ROOT/scripts/start-hidden.sh"
-  i=0
-  while [ "$i" -lt 40 ]; do
-    # No -f: a 503 before a token is set still proves the gateway is listening.
-    if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
-      if [ "$has_lsof" -eq 1 ]; then
-        new_pid="$(lsof -ti "tcp:$PORT" 2>/dev/null | head -n 1 || true)"
-        if [ -n "$new_pid" ] && [ "$new_pid" != "$old_pid" ]; then
-          echo "ModelDock gateway is healthy at http://127.0.0.1:$PORT (PID $new_pid)"
-          return
-        fi
-      else
-        echo "ModelDock gateway is healthy at http://127.0.0.1:$PORT"
-        return
-      fi
-    fi
-    sleep 0.25
-    i=$((i + 1))
-  done
-  # Roll back a bad self-update: if the current bundle never became healthy and the
-  # updater kept the previous one, restore it and try once more so a broken release
-  # does not leave the gateway dead (and Codex routed at it).
-  PREV="$ROOT/dist/modeldock.mjs.prev"
-  if [ -f "$PREV" ] && [ -f "$ROOT/dist/modeldock.mjs" ]; then
-    echo "New bundle did not become healthy; rolling back to the previous version." >&2
-    cp "$PREV" "$ROOT/dist/modeldock.mjs"
-    "$ROOT/scripts/start-hidden.sh"
-    i=0
-    while [ "$i" -lt 40 ]; do
-      if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
-        echo "Rolled back to the previous bundle; gateway is healthy at http://127.0.0.1:$PORT"
-        return
-      fi
-      sleep 0.25
-      i=$((i + 1))
-    done
+  if "$restart"; then return; else restart_status=$?; fi
+  # Codes 2 and 3 are ownership/PID-safety refusals, not a bad release. Never
+  # replace files while a listener we cannot safely stop may still be running.
+  if [ "$restart_status" -eq 2 ] || [ "$restart_status" -eq 3 ]; then exit "$restart_status"; fi
+  echo "New installed version did not become healthy; restoring the complete previous version set." >&2
+  if restore_previous_update && "$ROOT/scripts/restart.sh"; then
+    echo "Rolled back the complete installed version; gateway is healthy."
+    return
   fi
   echo "Gateway did not become healthy. Check $ROOT/modeldock.log" >&2
   exit 1

--- a/scripts/recover.sh
+++ b/scripts/recover.sh
@@ -86,6 +86,24 @@ restart_gateway() {
     sleep 0.25
     i=$((i + 1))
   done
+  # Roll back a bad self-update: if the current bundle never became healthy and the
+  # updater kept the previous one, restore it and try once more so a broken release
+  # does not leave the gateway dead (and Codex routed at it).
+  PREV="$ROOT/dist/modeldock.mjs.prev"
+  if [ -f "$PREV" ] && [ -f "$ROOT/dist/modeldock.mjs" ]; then
+    echo "New bundle did not become healthy; rolling back to the previous version." >&2
+    cp "$PREV" "$ROOT/dist/modeldock.mjs"
+    "$ROOT/scripts/start-hidden.sh"
+    i=0
+    while [ "$i" -lt 40 ]; do
+      if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
+        echo "Rolled back to the previous bundle; gateway is healthy at http://127.0.0.1:$PORT"
+        return
+      fi
+      sleep 0.25
+      i=$((i + 1))
+    done
+  fi
   echo "Gateway did not become healthy. Check $ROOT/modeldock.log" >&2
   exit 1
 }

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -70,15 +70,18 @@ if ($listener) {
   Write-Status "restart.ps1: no gateway on port $port; starting fresh"
 }
 
-$logDir = Join-Path $env:TEMP "modeldock"
-New-Item -ItemType Directory -Force -Path $logDir | Out-Null
-$stdout = Join-Path $logDir "gateway.log"
-$stderr = Join-Path $logDir "gateway.err.log"
+$log = Join-Path $root "modeldock.log"
+# Rotate at startup, one previous generation (same policy as start-hidden.ps1):
+# the log is append-only for the life of the process, so a cap on growth can
+# only be applied between runs.
+if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  Move-Item -LiteralPath $log -Destination "$log.1" -Force
+}
 
 # The old gateway's stdout/stderr handles can linger for a moment after
-# Stop-Process. Wait for both log files to become writable; if they stay
-# locked, fall back to per-run log files so Start-Process never races the
-# dying process's file handles.
+# Stop-Process. Wait for the log to become writable; if it stays locked, fall
+# back to a per-run log file so the redirect never races the dying process's
+# file handles.
 function Test-WritableFile($file) {
   try {
     $probe = [System.IO.File]::Open($file, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
@@ -90,7 +93,7 @@ function Test-WritableFile($file) {
 }
 $logsReady = $false
 for ($i = 0; $i -lt 20; $i += 1) {
-  if ((Test-WritableFile $stdout) -and (Test-WritableFile $stderr)) {
+  if (Test-WritableFile $log) {
     $logsReady = $true
     break
   }
@@ -98,9 +101,8 @@ for ($i = 0; $i -lt 20; $i += 1) {
 }
 if (-not $logsReady) {
   $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
-  $stdout = Join-Path $logDir "gateway-$stamp.log"
-  $stderr = Join-Path $logDir "gateway-$stamp.err.log"
-  Write-Status "WARNING: gateway.log was still locked; using per-run logs ($stamp)"
+  $log = Join-Path $root "modeldock-$stamp.log"
+  Write-Status "WARNING: modeldock.log was still locked; using per-run log ($log)"
 }
 
 # Prefer an explicit path, then a bundled Node under <root>\node (the installer
@@ -131,15 +133,17 @@ $server = Join-Path $root "src\server.mjs"
 if (-not (Test-Path -LiteralPath $server)) { $server = Join-Path $root "dist\modeldock.mjs" }
 
 try {
-  # Quote the script path: an installed layout under a home dir with a space
-  # (e.g. "C:\Users\Chen Bao\.modeldock") would otherwise be split by node's CRT
-  # into two argv entries and fail with "Cannot find module".
-  Start-Process -FilePath $nodeExe -ArgumentList "`"$server`"" -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+  # Quote both paths: an installed layout under a home dir with a space
+  # (e.g. "C:\Users\Chen Bao\.modeldock") would otherwise be split by node's
+  # CRT into two argv entries and fail with "Cannot find module". cmd.exe does
+  # the >> redirection so stdout and stderr share the same log file as the
+  # start-hidden launcher (and the "check modeldock.log" guidance).
+  Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden
 } catch {
   Write-Status "ERROR: failed to start gateway: $($_.Exception.Message)"
   exit 1
 }
-Write-Status "restart.ps1: started gateway from $root (logs: $logDir)"
+Write-Status "restart.ps1: started gateway from $root (logs: $log)"
 
 for ($i = 0; $i -lt 40; $i += 1) {
   Start-Sleep -Milliseconds 250
@@ -159,8 +163,8 @@ for ($i = 0; $i -lt 40; $i += 1) {
 }
 
 Write-Status "ERROR: gateway did not become healthy within 10s"
-if (Test-Path $stderr) {
-  $tail = Get-Content $stderr -Tail 10 -ErrorAction SilentlyContinue
+if (Test-Path $log) {
+  $tail = Get-Content $log -Tail 10 -ErrorAction SilentlyContinue
   if ($tail) { $tail | ForEach-Object { [Console]::Error.WriteLine($_) } }
 }
 exit 1

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -71,17 +71,12 @@ if ($listener) {
 }
 
 $log = Join-Path $root "modeldock.log"
-# Rotate at startup, one previous generation (same policy as start-hidden.ps1):
-# the log is append-only for the life of the process, so a cap on growth can
-# only be applied between runs.
-if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
-  Move-Item -LiteralPath $log -Destination "$log.1" -Force
-}
 
 # The old gateway's stdout/stderr handles can linger for a moment after
-# Stop-Process. Wait for the log to become writable; if it stays locked, fall
-# back to a per-run log file so the redirect never races the dying process's
-# file handles.
+# Stop-Process. Wait for the log to become writable BEFORE rotating: an
+# in-place Move-Item on a still-locked file fails, and that failure used to
+# abort the restart. If it stays locked, fall back to a per-run log file so
+# the redirect never races the dying process's file handles.
 function Test-WritableFile($file) {
   try {
     $probe = [System.IO.File]::Open($file, [System.IO.FileMode]::OpenOrCreate, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
@@ -103,6 +98,17 @@ if (-not $logsReady) {
   $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
   $log = Join-Path $root "modeldock-$stamp.log"
   Write-Status "WARNING: modeldock.log was still locked; using per-run log ($log)"
+} elseif ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  # Rotate at startup, one previous generation (same policy as start-hidden.ps1):
+  # the log is append-only for the life of the process, so a cap on growth can
+  # only be applied between runs. 32 MB keeps roughly a month of daily use.
+  try {
+    Move-Item -LiteralPath $log -Destination "$log.1" -Force
+  } catch {
+    # Rotation is best-effort now that the lock wait passed; a raced lock must
+    # not turn a restart into a failure.
+    Write-Status "WARNING: could not rotate modeldock.log: $($_.Exception.Message)"
+  }
 }
 
 # Prefer an explicit path, then a bundled Node under <root>\node (the installer

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -131,7 +131,10 @@ $server = Join-Path $root "src\server.mjs"
 if (-not (Test-Path -LiteralPath $server)) { $server = Join-Path $root "dist\modeldock.mjs" }
 
 try {
-  Start-Process -FilePath $nodeExe -ArgumentList $server -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+  # Quote the script path: an installed layout under a home dir with a space
+  # (e.g. "C:\Users\Chen Bao\.modeldock") would otherwise be split by node's CRT
+  # into two argv entries and fail with "Cannot find module".
+  Start-Process -FilePath $nodeExe -ArgumentList "`"$server`"" -WorkingDirectory $root -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
 } catch {
   Write-Status "ERROR: failed to start gateway: $($_.Exception.Message)"
   exit 1
@@ -141,13 +144,17 @@ Write-Status "restart.ps1: started gateway from $root (logs: $logDir)"
 for ($i = 0; $i -lt 40; $i += 1) {
   Start-Sleep -Milliseconds 250
   try {
-    $health = Invoke-RestMethod -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2
-    if ($health.ok) {
-      Write-Status "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    Invoke-WebRequest -Uri "http://127.0.0.1:$port/healthz" -TimeoutSec 2 -UseBasicParsing | Out-Null
+    Write-Status "restart.ps1: gateway healthy at http://127.0.0.1:$port"
+    exit 0
+  } catch {
+    # A returned HTTP status (e.g. 503 before a token is configured) still proves
+    # the gateway is up and listening - only a connection failure means it is not.
+    if ($_.Exception.Response) {
+      Write-Status "restart.ps1: gateway up at http://127.0.0.1:$port (awaiting token)"
       exit 0
     }
-  } catch {
-    # Gateway still booting; keep polling.
+    # Otherwise still booting / connection refused; keep polling.
   }
 }
 

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -122,7 +122,10 @@ wait_for_health() {
   old_pid="${1:-}"
   i=0
   while [ "$i" -lt 40 ]; do
-    if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    # No -f: a 503 (gateway up but no token yet) still proves the process is
+    # listening. -f would treat that as a failure and loop until the timeout,
+    # reporting a healthy fresh install as "did not start".
+    if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null; then
       new_pid="$(find_listener_pid)"
       if [ -z "$old_pid" ] || [ -z "$new_pid" ] || [ "$new_pid" != "$old_pid" ]; then
         status "restart.sh: gateway healthy at http://127.0.0.1:$PORT"

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -36,18 +36,23 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 find_listener_pid() {
+  pid=""
   if command -v lsof >/dev/null 2>&1; then
-    lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
-  elif command -v ss >/dev/null 2>&1; then
+    pid="$(lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true)"
+    if [ -n "$pid" ]; then printf '%s\n' "$pid"; return; fi
+  fi
+  if command -v ss >/dev/null 2>&1; then
     # Minimal Linux images (Debian/Ubuntu containers) ship neither lsof nor
     # psmisc, but do ship ss. Without this branch the old PID is never found and
     # the new gateway dies with EADDRINUSE while the stale one keeps answering.
-    ss -tlnpH "sport = :$PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -n 1 | cut -d= -f2 || true
-  elif command -v fuser >/dev/null 2>&1; then
-    fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true
-  else
-    true
+    pid="$(ss -tlnpH "sport = :$PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -n 1 | cut -d= -f2 || true)"
+    if [ -n "$pid" ]; then printf '%s\n' "$pid"; return; fi
   fi
+  if command -v fuser >/dev/null 2>&1; then
+    pid="$(fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true)"
+    if [ -n "$pid" ]; then printf '%s\n' "$pid"; return; fi
+  fi
+  true
 }
 
 resolve_node() {
@@ -90,6 +95,11 @@ if [ ! -f "$SERVER" ]; then
 fi
 
 OLD_PID="$(find_listener_pid)"
+if curl -sS -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz" 2>/dev/null \
+    && [ -z "$OLD_PID" ]; then
+  status "ERROR: port $PORT is active but its listener PID could not be identified; refusing a fake restart"
+  exit 3
+fi
 
 check_owner() {
   [ -n "$OLD_PID" ] || return 0
@@ -192,6 +202,7 @@ if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 33554432 ]; then
 fi
 
 nohup "$NODE_BIN" "$SERVER" >>"$LOG" 2>&1 &
+NEW_PID=$!
 status "restart.sh: started gateway from $ROOT (logs: $LOG)"
 
 if wait_for_health "$OLD_PID"; then
@@ -199,6 +210,8 @@ if wait_for_health "$OLD_PID"; then
 fi
 
 status "ERROR: gateway did not become healthy within 10s"
+kill "$NEW_PID" 2>/dev/null || true
+wait "$NEW_PID" 2>/dev/null || true
 if [ -f "$LOG" ]; then
   tail -n 10 "$LOG" >&2 || true
 fi

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -38,6 +38,11 @@ fi
 find_listener_pid() {
   if command -v lsof >/dev/null 2>&1; then
     lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
+  elif command -v ss >/dev/null 2>&1; then
+    # Minimal Linux images (Debian/Ubuntu containers) ship neither lsof nor
+    # psmisc, but do ship ss. Without this branch the old PID is never found and
+    # the new gateway dies with EADDRINUSE while the stale one keeps answering.
+    ss -tlnpH "sport = :$PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -n 1 | cut -d= -f2 || true
   elif command -v fuser >/dev/null 2>&1; then
     fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true
   else

--- a/scripts/start-hidden.ps1
+++ b/scripts/start-hidden.ps1
@@ -39,8 +39,14 @@ if (-not $nodeExe) {
 $log = Join-Path $root "modeldock.log"
 # Rotate at startup, one previous generation (like codex-router's log-rotation):
 # the log is append-only for the life of the process, so a cap on growth can only
-# be applied between runs. 32 MB keeps roughly a month of daily use.
+# be applied between runs. 32 MB keeps roughly a month of daily use. Rotation is
+# best-effort: a previous gateway whose handles have not released must not fail
+# this hidden start.
 if ((Test-Path -LiteralPath $log) -and ((Get-Item -LiteralPath $log).Length -gt 32MB)) {
+  try {
     Move-Item -LiteralPath $log -Destination "$log.1" -Force
+  } catch {
+    Write-Output "WARNING: could not rotate modeldock.log: $($_.Exception.Message)"
+  }
 }
 Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"`"$nodeExe`" `"$server`" >> `"$log`" 2>&1`"" -WorkingDirectory $root -WindowStyle Hidden

--- a/scripts/start-hidden.sh
+++ b/scripts/start-hidden.sh
@@ -11,7 +11,7 @@ else
 fi
 PORT="${MODELDOCK_PORT:-4097}"
 if [ -f "$ROOT/.env" ]; then
-  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1)"
+  ENV_PORT="$(sed -n 's/^MODELDOCK_PORT=//p' "$ROOT/.env" | tail -n 1 | tr -d '\r' || true)"
   [ -n "$ENV_PORT" ] && PORT="$ENV_PORT"
 fi
 if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:$PORT/healthz"; then
@@ -34,7 +34,9 @@ if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then
   if [ -n "$BEST_BIN" ]; then
     NODE_BIN="$BEST_BIN"
   else
-    NODE_BIN="$(command -v node)"
+    # `set -e` turns a failed command substitution into an immediate exit, so
+    # the friendly error below would never run; keep the substitution false-safe.
+    NODE_BIN="$(command -v node || true)"
   fi
 fi
 if [ -z "$NODE_BIN" ] || [ ! -x "$NODE_BIN" ]; then

--- a/scripts/sync-installer-helpers.mjs
+++ b/scripts/sync-installer-helpers.mjs
@@ -1,0 +1,91 @@
+// Keep the single-file installers' embedded helper scripts byte-equivalent to
+// the standalone release assets. Run without arguments to update the installers,
+// or with --check in CI to fail when a helper changed without being re-embedded.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function normalized(source, newline) {
+  return String(source).replace(/\r\n/g, "\n").replace(/\n$/, "").replace(/\n/g, newline);
+}
+
+function lineEndAt(source, index) {
+  const end = source.indexOf("\n", index);
+  if (end < 0) throw new Error("unterminated installer marker");
+  return end + 1;
+}
+
+function replacePowerShellBlock(installer, variable, helper) {
+  const assignment = installer.indexOf(`$${variable} =`);
+  if (assignment < 0) throw new Error(`install.ps1 is missing $${variable}`);
+  const opener = installer.indexOf("@'", assignment);
+  const contentStart = lineEndAt(installer, opener);
+  const newline = installer.slice(contentStart - 2, contentStart) === "\r\n" ? "\r\n" : "\n";
+  const closer = `${newline}'@ | Out-File -FilePath $${variable}`;
+  const contentEnd = installer.indexOf(closer, contentStart);
+  if (contentEnd < 0) throw new Error(`install.ps1 cannot find the $${variable} heredoc end`);
+  return `${installer.slice(0, contentStart)}${normalized(helper, newline)}${installer.slice(contentEnd)}`;
+}
+
+function replaceShellBlock(installer, variable, helper) {
+  const assignment = installer.indexOf(`${variable}=`);
+  if (assignment < 0) throw new Error(`install.sh is missing ${variable}`);
+  const opener = installer.indexOf("<<'EOF'", assignment);
+  const contentStart = lineEndAt(installer, opener);
+  const newline = installer.slice(contentStart - 2, contentStart) === "\r\n" ? "\r\n" : "\n";
+  const contentEnd = installer.indexOf(`${newline}EOF`, contentStart);
+  if (contentEnd < 0) throw new Error(`install.sh cannot find the ${variable} heredoc end`);
+  return `${installer.slice(0, contentStart)}${normalized(helper, newline)}${installer.slice(contentEnd)}`;
+}
+
+function helper(name) {
+  return readFileSync(path.join(repoRoot, "scripts", name), "utf8");
+}
+
+const files = [
+  {
+    name: "install.ps1",
+    sync(source) {
+      let result = source;
+      for (const [variable, name] of [["launcher", "start-hidden.ps1"], ["restart", "restart.ps1"], ["recover", "recover.ps1"]]) {
+        result = replacePowerShellBlock(result, variable, helper(name));
+      }
+      return result;
+    },
+  },
+  {
+    name: "install.sh",
+    sync(source) {
+      let result = source;
+      for (const [variable, name] of [["LAUNCHER", "start-hidden.sh"], ["RESTART", "restart.ps1"], ["RESTART_SH", "restart.sh"], ["RECOVER", "recover.sh"]]) {
+        result = replaceShellBlock(result, variable, helper(name));
+      }
+      return result;
+    },
+  },
+];
+
+const check = process.argv.includes("--check");
+const drift = [];
+for (const file of files) {
+  const target = path.join(repoRoot, "scripts", file.name);
+  const current = readFileSync(target, "utf8");
+  const next = file.sync(current);
+  if (next === current) continue;
+  drift.push(file.name);
+  if (!check) writeFileSync(target, next, "utf8");
+}
+
+if (drift.length) {
+  if (check) {
+    console.error(`installer helper drift: ${drift.join(", ")}; run node scripts/sync-installer-helpers.mjs`);
+    process.exitCode = 1;
+  } else {
+    console.log(`synchronized installer helpers: ${drift.join(", ")}`);
+  }
+} else {
+  console.log("installer helper copies are synchronized");
+}

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -6,7 +6,10 @@
 # (config.toml.modeldock-backup-*) is also kept for recovery.
 $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
-$stateDir = if ($env:MODELDOCK_ROOT) { $env:MODELDOCK_ROOT } else { Join-Path $HOME ".modeldock" }
+# Runtime state (owner records, caller key, catalog, memory) follows
+# MODELDOCK_STATE_DIR everywhere else; MODELDOCK_ROOT only ever names the
+# install directory. Honour both so a custom state dir is cleaned up too.
+$stateDir = if ($env:MODELDOCK_STATE_DIR) { $env:MODELDOCK_STATE_DIR } elseif ($env:MODELDOCK_ROOT) { $env:MODELDOCK_ROOT } else { Join-Path $HOME ".modeldock" }
 $log = Join-Path $root "modeldock.log"
 $port = if ($env:MODELDOCK_PORT) { [int]$env:MODELDOCK_PORT } else { 4097 }
 $runKey = if ($env:MODELDOCK_AUTOSTART_KEY) { $env:MODELDOCK_AUTOSTART_KEY } else { "HKCU\Software\Microsoft\Windows\CurrentVersion\Run" }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,7 +7,10 @@
 # (config.toml.modeldock-backup-*) is also kept for recovery.
 set -eu
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-STATE_DIR="${MODELDOCK_ROOT:-$HOME/.modeldock}"
+# Runtime state (owner records, caller key, catalog, memory) follows
+# MODELDOCK_STATE_DIR everywhere else; MODELDOCK_ROOT only ever names the
+# install directory. Honour both so a custom state dir is cleaned up too.
+STATE_DIR="${MODELDOCK_STATE_DIR:-${MODELDOCK_ROOT:-$HOME/.modeldock}}"
 LOG="$ROOT/modeldock.log"
 PORT="${MODELDOCK_PORT:-4097}"
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -18,9 +18,41 @@ OWNER_PID=""
 if [ -f "$OWNER_FILE" ]; then
   OWNER_PID=$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$OWNER_FILE" | head -n 1)
 fi
-if [ -n "$OWNER_PID" ] && kill -0 "$OWNER_PID" 2>/dev/null; then
+
+find_listener_pid() {
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
+  elif command -v ss >/dev/null 2>&1; then
+    ss -tlnpH "sport = :$PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -n 1 | cut -d= -f2 || true
+  elif command -v fuser >/dev/null 2>&1; then
+    fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true
+  else
+    true
+  fi
+}
+
+# Confirm the recorded PID is really our gateway before killing it: after a reboot
+# the owner file can name a PID that has since been reused by an unrelated process.
+# Accept it only if it is the current listener on our port, or its command line
+# references this install root.
+owner_is_ours() {
+  pid="$1"
+  [ -n "$pid" ] || return 1
+  listener="$(find_listener_pid)"
+  [ -n "$listener" ] && [ "$listener" = "$pid" ] && return 0
+  cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  case "$cmd" in
+    *"$ROOT"*) return 0 ;;
+    *"$STATE_DIR"*) return 0 ;;
+  esac
+  return 1
+}
+
+if [ -n "$OWNER_PID" ] && kill -0 "$OWNER_PID" 2>/dev/null && owner_is_ours "$OWNER_PID"; then
   kill "$OWNER_PID" 2>/dev/null || true
   echo "Stopped gateway process $OWNER_PID"
+elif [ -n "$OWNER_PID" ] && kill -0 "$OWNER_PID" 2>/dev/null; then
+  echo "WARNING: recorded PID $OWNER_PID is not listening on port $PORT and does not look like this install; not killing (possible PID reuse)."
 else
   echo "WARNING: no live ModelDock-owned gateway found on port $PORT; nothing was stopped."
 fi

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { bareModelId, profileById, TRIAL_MAIN_MODEL, TRIAL_VISION_MODEL } from "./profiles.mjs";
+import { bareModelId, profileById, publishedSlugFor, TRIAL_MAIN_MODEL, TRIAL_VISION_MODEL } from "./profiles.mjs";
 import { readNativeCatalog } from "./native-catalog.mjs";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -32,8 +32,13 @@ export function baseInstructionsFor(config) {
 // that answers "what can this model do" for Codex.
 export function catalogFor(config) {
   const profile = config.profile || profileById(config.profileId || "opencode-go");
+  // Every published entry is owner-qualified, the main model included: a bare
+  // mainModel reference (legacy .env or a test fixture) is normalized to its
+  // published form so the catalog never carries an id whose label and route
+  // could disagree. Ids no profile owns (native GPT ids, unknown) pass through.
+  const mainModel = publishedSlugFor(config.profileId || profile.id, config.mainModel);
   const catalog = profile.modelCatalog({
-    mainModel: config.mainModel,
+    mainModel,
     visionModel: config.visionModel,
     baseInstructions: baseInstructionsFor(config),
   });

--- a/src/catalog.test.mjs
+++ b/src/catalog.test.mjs
@@ -22,7 +22,7 @@ function configStub() {
 
 test("catalogFor declares image input for the text-only main model (image escalation)", () => {
   const catalog = catalogFor(configStub());
-  const main = catalog.models.find((entry) => entry.slug === "deepseek-v4-flash");
+  const main = catalog.models.find((entry) => entry.slug === "deepseek-v4-flash@opencode-go");
   assert.ok(main, "main model entry exists");
   assert.deepEqual(main.input_modalities, ["text", "image"], "endpoint handles images by escalating to the vision model");
   assert.equal(main.supports_search_tool, false, "search is the MCP tool, not a hosted schema");
@@ -32,7 +32,7 @@ test("catalogFor declares image input for the text-only main model (image escala
 
 test("catalogFor keeps the main model first with the profile comp hash", () => {
   const catalog = catalogFor(configStub());
-  assert.equal(catalog.models[0].slug, "deepseek-v4-flash");
+  assert.equal(catalog.models[0].slug, "deepseek-v4-flash@opencode-go");
   assert.equal(catalog.models[0].comp_hash, "modeldock-opencode-go-v1");
   assert.equal(catalog.models[0].context_window, 400_000, "deepseek-v4-flash declares 400k so Codex compacts at 320k");
   assert.equal(catalog.models[0].auto_compact_token_limit, 320_000);
@@ -100,7 +100,7 @@ test("enabledProvidersFor includes the active profile and any provider with a to
 test("catalogFor publishes only models owned by enabled providers", () => {
   const catalog = catalogFor(configStub());
   const slugs = catalog.models.map((entry) => entry.slug);
-  assert.ok(slugs.includes("deepseek-v4-flash"));
+  assert.ok(slugs.includes("deepseek-v4-flash@opencode-go"));
   assert.ok(!slugs.some((slug) => slug.endsWith("@deepseek-official")), "DeepSeek official models are hidden without a token");
 
   const withDeepSeek = {
@@ -156,7 +156,7 @@ test("catalogFor with nativeMerge=false skips the native GPT merge for non-subsc
   try {
     const catalog = catalogFor({ ...configStub(), nativeCatalogFile: file, nativeMerge: false });
     const slugs = catalog.models.map((entry) => entry.slug);
-    assert.ok(slugs.includes("deepseek-v4-flash"), "curated Go models stay published");
+  assert.ok(slugs.includes("deepseek-v4-flash@opencode-go"), "curated Go models stay published");
     assert.ok(!slugs.includes("gpt-5.6-luna"), "native GPT models are hidden without a subscription (nativeMerge=false)");
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -178,8 +178,8 @@ test("catalogFor in trial mode publishes only the fixed free pair and never merg
       visionModel: "mimo-v2.5-free",
       nativeCatalogFile: file,
     });
-    assert.deepEqual(trial.models.map((entry) => entry.slug).sort(), ["deepseek-v4-flash-free", "mimo-v2.5-free"]);
-    assert.equal(trial.models[0].slug, "deepseek-v4-flash-free", "the fixed trial main model leads");
+    assert.deepEqual(trial.models.map((entry) => entry.slug).sort(), ["deepseek-v4-flash-free@opencode-go", "mimo-v2.5-free@opencode-go"]);
+    assert.equal(trial.models[0].slug, "deepseek-v4-flash-free@opencode-go", "the fixed trial main model leads");
     assert.ok(!trial.models.some((entry) => entry.slug === "gpt-5.6-luna"), "trial never merges native GPT models");
 
     // The same native capture outside trial publishes the native model.
@@ -193,8 +193,8 @@ test("catalogFor in trial mode publishes only the fixed free pair and never merg
 test("catalogFor outside trial still publishes the free models alongside the paid ones", () => {
   const catalog = catalogFor(configStub());
   const slugs = catalog.models.map((entry) => entry.slug);
-  assert.ok(slugs.includes("deepseek-v4-flash-free"));
-  assert.ok(slugs.includes("mimo-v2.5-free"));
+  assert.ok(slugs.includes("deepseek-v4-flash-free@opencode-go"));
+  assert.ok(slugs.includes("mimo-v2.5-free@opencode-go"));
 });
 
 test("mergeNativeCatalog caps native reasoning levels to the published enum", () => {

--- a/src/config-switcher.mjs
+++ b/src/config-switcher.mjs
@@ -329,6 +329,19 @@ export class CodexConfigSwitcher {
       if (error.code !== "ENOENT") throw error;
       originalExisted = false;
     }
+    // Crash recovery: enable() only runs with state.enabled false, but a crash
+    // between the config write and the state write of a prior enable() leaves the
+    // config already managed while state says disabled. Backing that up as the
+    // "original" would poison the backup chain - a later disable, seeing the
+    // managed hash match, would restore a still-managed config and leave Codex
+    // routed at a dead gateway. Strip our managed route first so the backup we take
+    // is the true pre-ModelDock baseline.
+    let originalWasManaged = false;
+    if (originalExisted && hasManagedRoute(original)) {
+      originalWasManaged = true;
+      const nl = original.includes("\r\n") ? "\r\n" : "\n";
+      original = `${removeManagedRoute(original.replace(/\r\n/g, "\n").split("\n")).join("\n").replace(/\n/g, nl)}${nl}`;
+    }
     if (hasCodexRouterBlock(original)) {
       throw Object.assign(
         new Error("codex-router also manages openai_base_url; disable its integration before enabling ModelDock."),
@@ -341,8 +354,14 @@ export class CodexConfigSwitcher {
     if (originalExisted) assertConfigWriteSafe(original);
 
     const backupPath = path.join(this.codexHome, `config.toml.modeldock-backup-${timestamp()}-${randomUUID().slice(0, 8)}`);
-    if (originalExisted) await copyFile(this.configPath, backupPath);
-    else await writeFile(backupPath, "", { encoding: "utf8", flag: "wx", mode: 0o600 });
+    if (originalExisted && originalWasManaged) {
+      // Persist the stripped baseline, not the managed file still on disk.
+      await writeFile(backupPath, original, { encoding: "utf8", mode: 0o600 });
+    } else if (originalExisted) {
+      await copyFile(this.configPath, backupPath);
+    } else {
+      await writeFile(backupPath, "", { encoding: "utf8", flag: "wx", mode: 0o600 });
+    }
 
     const managed = buildManagedCodexConfig(original, {
       baseUrl: this.baseUrl,

--- a/src/config-switcher.mjs
+++ b/src/config-switcher.mjs
@@ -22,6 +22,7 @@ function tomlString(value) {
 // fields live inside a sentinel block so detection and restore are exact.
 const MANAGED_BEGIN = /^\s*#\s*BEGIN\s+modeldock-managed\s*(?:#.*)?$/m;
 const MANAGED_END = /^\s*#\s*END\s+modeldock-managed\s*(?:#.*)?$/m;
+const MANAGED_ORIGINAL_EXISTED = /^\s*#\s*ModelDock original config existed:\s*(true|false)\s*$/im;
 const CODERX_ROUTER_BEGIN = /^\s*#\s*BEGIN\s+codex-router-managed\s*(?:#.*)?$/m;
 
 // Every top-level key ModelDock may write. Restoring a backup puts the user's own
@@ -186,7 +187,7 @@ function setTopLevel(lines, key, value) {
 // base URL is redirected to the local gate, and the realtime endpoints point at
 // OpenAI so Codex Voice never dials the loopback. The catalog file keeps naming
 // our models in the App picker (openai/codex#32119 only affects custom providers).
-export function buildManagedCodexConfig(source, { baseUrl, model, catalogFile = "", mcpUrl = "", mcpCommand = "", mcpArgs = [], mcpEnv = {} }) {
+export function buildManagedCodexConfig(source, { baseUrl, model, catalogFile = "", mcpUrl = "", mcpCommand = "", mcpArgs = [], mcpEnv = {}, originalExisted = true }) {
   const newline = source.includes("\r\n") ? "\r\n" : "\n";
   let lines = removeManagedRoute(source.replace(/\r\n/g, "\n").split("\n"));
   while (lines.length && !lines.at(-1).trim()) lines.pop();
@@ -195,6 +196,7 @@ export function buildManagedCodexConfig(source, { baseUrl, model, catalogFile = 
   const managed = [
     "# BEGIN modeldock-managed",
     "# Managed by ModelDock: keeps the built-in openai provider and points it at the local gate.",
+    `# ModelDock original config existed: ${originalExisted ? "true" : "false"}`,
     `openai_base_url = ${tomlString(baseUrl)}`,
   ];
   if (catalogFile) managed.push(`model_catalog_json = ${tomlString(catalogFile)}`);
@@ -339,8 +341,16 @@ export class CodexConfigSwitcher {
     let originalWasManaged = false;
     if (originalExisted && hasManagedRoute(original)) {
       originalWasManaged = true;
+      const existenceMarker = MANAGED_ORIGINAL_EXISTED.exec(original)?.[1]?.toLowerCase();
       const nl = original.includes("\r\n") ? "\r\n" : "\n";
       original = `${removeManagedRoute(original.replace(/\r\n/g, "\n").split("\n")).join("\n").replace(/\n/g, nl)}${nl}`;
+      // New managed configs carry this crash-recovery marker. For older configs,
+      // a managed-only file is the best available proof that config.toml did not
+      // exist before enable() wrote it.
+      if (existenceMarker === "false" || (!existenceMarker && !original.trim())) {
+        originalExisted = false;
+        original = "";
+      }
     }
     if (hasCodexRouterBlock(original)) {
       throw Object.assign(
@@ -371,6 +381,7 @@ export class CodexConfigSwitcher {
       mcpCommand: this.mcpCommand,
       mcpArgs: this.mcpArgs,
       mcpEnv: this.mcpEnv,
+      originalExisted,
     });
     // Defensive: the writer must never emit duplicates either (setTopLevel
     // dedupes `model`, the managed block owns its keys, but a future edit could

--- a/src/config-switcher.test.mjs
+++ b/src/config-switcher.test.mjs
@@ -116,6 +116,29 @@ test("defaults off, backs up on enable, and restores exact config on disable", a
   assert.doesNotMatch(await readFile(configPath, "utf8"), /mcp_servers\.modeldock/, "restore removes the ModelDock MCP section");
 });
 
+test("re-enable after a crash that left the config managed does not poison the backup chain", async (t) => {
+  const { codexHome, configPath, switcher } = await fixture(t);
+  await switcher.enable();
+  assert.match(await readFile(configPath, "utf8"), /openai_base_url = "http:\/\/127\.0\.0\.1:4097\/v1"/);
+
+  // Simulate a crash between the config write and the state write of a *fresh*
+  // enable: the config is managed on disk but the switch state reads as disabled.
+  await rm(path.join(codexHome, "modeldock", "config-switch-state.json"), { force: true });
+  assert.equal((await switcher.status()).enabled, false);
+
+  // The re-enable must back up the pre-ModelDock baseline, not the managed file,
+  // so a later disable cannot restore a still-managed config.
+  const reEnabled = await switcher.enable();
+  const backup = await readFile(reEnabled.backupPath, "utf8");
+  assert.doesNotMatch(backup, /127\.0\.0\.1:4097/, "backup must not be the managed config");
+  assert.doesNotMatch(backup, /mcp_servers\.modeldock/);
+
+  await switcher.disable();
+  const restored = await readFile(configPath, "utf8");
+  assert.doesNotMatch(restored, /openai_base_url = "http:\/\/127\.0\.0\.1:4097/, "disable must return Codex to the native route");
+  assert.doesNotMatch(restored, /mcp_servers\.modeldock/);
+});
+
 test("markOnboarded persists and survives enable/disable round trips", async (t) => {
   const { switcher } = await fixture(t);
   const fresh = await switcher.status();

--- a/src/config-switcher.test.mjs
+++ b/src/config-switcher.test.mjs
@@ -139,6 +139,24 @@ test("re-enable after a crash that left the config managed does not poison the b
   assert.doesNotMatch(restored, /mcp_servers\.modeldock/);
 });
 
+test("crash recovery preserves that config.toml originally did not exist", async (t) => {
+  const codexHome = await mkdtemp(path.join(os.tmpdir(), "modeldock-config-switch-absent-"));
+  t.after(() => rm(codexHome, { recursive: true, force: true }));
+  const configPath = path.join(codexHome, "config.toml");
+  const switcher = new CodexConfigSwitcher({
+    codexHome,
+    baseUrl: "http://127.0.0.1:4097/v1",
+    model: "deepseek-v4-flash",
+  });
+
+  await switcher.enable();
+  assert.match(await readFile(configPath, "utf8"), /ModelDock original config existed: false/);
+  await rm(path.join(codexHome, "modeldock", "config-switch-state.json"), { force: true });
+  await switcher.enable();
+  await switcher.disable();
+  await assert.rejects(() => access(configPath), { code: "ENOENT" });
+});
+
 test("markOnboarded persists and survives enable/disable round trips", async (t) => {
   const { switcher } = await fixture(t);
   const fresh = await switcher.status();

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -39,10 +39,18 @@ export function parseEnvFile(source) {
   return entries;
 }
 
+// The .env format is line-based, so a value carrying a newline would inject
+// additional KEY=VALUE lines that take effect on the next load (e.g. a crafted
+// custom-model id turning MODELDOCK_REQUIRE_CALLER_KEY off). No legitimate value
+// here (token, url, model id) contains a CR/LF, so strip them at every write.
+export function sanitizeEnvValue(value) {
+  return String(value).replace(/[\r\n]+/g, " ").trim();
+}
+
 export function serializeEnvFile(entries) {
   return Object.entries(entries)
     .filter(([, value]) => value !== undefined && value !== null)
-    .map(([key, value]) => `${key}=${value}`)
+    .map(([key, value]) => `${key}=${sanitizeEnvValue(value)}`)
     .join("\n") + "\n";
 }
 
@@ -90,8 +98,9 @@ export function writeEnvFile(updates, file = envFileFor()) {
     for (const line of lines) {
       const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
       if (match && updated.has(match[1])) {
-        // Secrets are stored encrypted on disk; everything else stays as given.
-        const value = isSecretKey(match[1]) ? encryptSecret(updates[match[1]]) : updates[match[1]];
+        // Secrets are stored encrypted on disk; everything else stays as given
+        // (minus any CR/LF, which would inject extra .env lines - see sanitizeEnvValue).
+        const value = isSecretKey(match[1]) ? encryptSecret(updates[match[1]]) : sanitizeEnvValue(updates[match[1]]);
         next.push(`${match[1]}=${value}`);
         updated.delete(match[1]);
       } else {
@@ -99,7 +108,7 @@ export function writeEnvFile(updates, file = envFileFor()) {
       }
     }
     for (const key of updated) {
-      const value = isSecretKey(key) ? encryptSecret(updates[key]) : updates[key];
+      const value = isSecretKey(key) ? encryptSecret(updates[key]) : sanitizeEnvValue(updates[key]);
       next.push(`${key}=${value}`);
     }
     const content = next.join("\n").replace(/\n+$/, "\n");

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -676,9 +676,10 @@ function usageFromEvent(event) {
 export async function pipeGatewayStream(upstreamBody, res, tee, onFirstResponse) {
   if (!upstreamBody) {
     res.end();
-    return 0;
+    return { bytes: 0, interrupted: false };
   }
   let bytes = 0;
+  let interrupted = false;
   await new Promise((resolve, reject) => {
     const stream = Readable.fromWeb(upstreamBody);
     let firstResponseMarked = false;
@@ -702,12 +703,15 @@ export async function pipeGatewayStream(upstreamBody, res, tee, onFirstResponse)
     res.once("finish", () => settle());
     res.once("error", settle);
     res.once("close", () => {
-      if (!settled) stream.destroy();
+      if (!settled) {
+        interrupted = true;
+        stream.destroy();
+      }
       settle();
     });
     stream.pipe(res);
   });
-  return bytes;
+  return { bytes, interrupted };
 }
 
 // Classify a 200 zen-free response body that silently failed. Returns
@@ -940,12 +944,15 @@ export async function relayNativeResponses(payload, res, services, { signal } = 
       res.setHeader("Cache-Control", "no-cache, no-transform");
       res.flushHeaders();
     }
-    const bytesOut = await pipeGatewayStream(upstream.body, res, tee, markFirstResponse);
+    const piped = await pipeGatewayStream(upstream.body, res, tee, markFirstResponse);
+    const bytesOut = piped.bytes;
+    const interrupted = piped.interrupted;
     markFirstResponse();
     finish?.({
-      ok: true,
-      httpStatus: upstream.status,
+      ok: !interrupted,
+      httpStatus: interrupted ? 499 : upstream.status,
       upstream: "openai",
+      error: interrupted ? "client disconnected" : undefined,
       bytesOut,
       inputTokens: usage?.input_tokens || 0,
       outputTokens: usage?.output_tokens || 0,
@@ -969,7 +976,7 @@ export async function relayNativeResponses(payload, res, services, { signal } = 
       model: payload.model,
       provider: "openai",
       route: "native_passthrough",
-      status: upstream.status,
+      status: interrupted ? 499 : upstream.status,
       durationMs: Date.now() - startedAt,
       inputTokens: usage?.input_tokens,
       outputTokens: usage?.output_tokens,
@@ -980,8 +987,8 @@ export async function relayNativeResponses(payload, res, services, { signal } = 
       threadId,
     });
     return {
-      ok: true,
-      httpStatus: upstream.status,
+      ok: !interrupted,
+      httpStatus: interrupted ? 499 : upstream.status,
       route: { model: payload.model, reason: "native_passthrough" },
       usage,
       bytesOut,
@@ -1034,7 +1041,10 @@ export async function relayNativeImage(payload, res, services, { signal } = {}) 
       res.setHeader("Cache-Control", "no-cache, no-transform");
       res.flushHeaders();
     }
-    await pipeGatewayStream(upstream.body, res, null);
+    const piped = await pipeGatewayStream(upstream.body, res, null);
+    if (piped.interrupted) {
+      return { ok: false, httpStatus: 499, error: "client disconnected" };
+    }
     return { ok: true, httpStatus: upstream.status };
   } catch (error) {
     if (!res.headersSent) {
@@ -1042,7 +1052,7 @@ export async function relayNativeImage(payload, res, services, { signal } = {}) 
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: { type: "upstream_failed", message: redactBearer(error.message) } }));
     } else {
-      res.destroy();
+      endRelayStreamFailure(res, redactBearer(error.message));
     }
     return { ok: false, httpStatus: 502, error: error.message };
   }
@@ -1247,9 +1257,10 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
       });
       return { ok: false, httpStatus: 502, route, error: "Compact response is too large." };
     }
-    const parsed = JSON.parse(bytes.toString("utf8"));
-    usage = extractResponseUsage(parsed);
     if (!upstream.ok) {
+      // Translate before parsing: a non-JSON upstream error (e.g. a proxy's HTML
+      // 502) must reach translateUpstreamError and writeCompactFailureReport, not
+      // throw out of a JSON.parse into the generic catch below.
       const translated = translateUpstreamError({ provider: target.provider, status: upstream.status, bodyText: redactBearer(bytes.toString("utf8")), free: target.free });
       writeCompactFailureReport(
         compactFailureReport(
@@ -1292,6 +1303,31 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
       return { ok: false, httpStatus: upstream.status, route, error: translated.body.error.message.slice(0, 400), upstreamBytes: bytes.length };
     }
 
+    let parsed;
+    try {
+      parsed = JSON.parse(bytes.toString("utf8"));
+    } catch {
+      // An OK response that is not JSON (a proxy's HTML, a truncated body): surface
+      // a translated provider error rather than throwing to the generic 502 catch.
+      const translated = translateUpstreamError({ provider: target.provider, status: 502, bodyText: redactBearer(bytes.toString("utf8")), free: target.free });
+      if (!res.headersSent) {
+        res.statusCode = 502;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(translated.body));
+      }
+      finish?.({ ok: false, httpStatus: 502, upstream: target.provider, error: translated.body.error.message.slice(0, 400) });
+      (services.recordUsage || recordUsageEvent)({
+        model: route.model,
+        provider: target.provider,
+        route: operation,
+        status: 502,
+        durationMs: Date.now() - startedAt,
+        sessionId,
+        threadId,
+      });
+      return { ok: false, httpStatus: 502, route, error: translated.body.error.message.slice(0, 400), upstreamBytes: bytes.length };
+    }
+    usage = extractResponseUsage(parsed);
     const summary = extractResponseText(parsed);
     if (v2) {
       if (payload.stream === false) {
@@ -1365,6 +1401,18 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
 // knownModels, visionModelOf } so the caller decides wiring.
 export async function relayResponses(payload, res, services, { signal } = {}) {
   const { config, metrics, mediaStore, routeAffinity, knownModels, incomingHeaders } = services;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    const error = {
+      error: {
+        type: "bad_request",
+        message: "Expected a JSON Responses request body.",
+      },
+    };
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(error));
+    return { ok: false, httpStatus: 400, route: { model: "", reason: "bad_request" }, error };
+  }
   const { sessionId, threadId } = sessionIdsFrom(incomingHeaders);
   const requestedModel = normalizeLegacySlug(typeof payload.model === "string" ? payload.model : "", knownModels);
   if (requestedModel !== payload.model && requestedModel) payload = { ...payload, model: requestedModel };
@@ -1511,6 +1559,7 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
     const freeEmptyError = target.free ? freeEmptyOutputError({ provider: target.provider }) : null;
     let upstreamBody = upstream.body;
     let freeEmpty = false;
+    let interrupted = false;
     if (target.free && normalizedPayload.stream !== true) {
       const raw = await upstream.text();
       let parsed = null;
@@ -1567,7 +1616,9 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
       freeEmpty = result.empty;
       if (result.usage) usage = result.usage;
     } else {
-      bytesOut = await pipeGatewayStream(upstreamBody, res, tee, markFirstResponse);
+      const piped = await pipeGatewayStream(upstreamBody, res, tee, markFirstResponse);
+      bytesOut = piped.bytes;
+      interrupted = piped.interrupted;
     }
     markFirstResponse();
     if (completedResponse && routeAffinity) {
@@ -1630,9 +1681,10 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
     // inputTokens/outputTokens ride on the trace record: the dashboard's
     // context-token waveform plots recent[].inputTokens per completed call.
     finish?.({
-      ok: true,
-      httpStatus: upstream.status,
+      ok: !interrupted,
+      httpStatus: interrupted ? 499 : upstream.status,
       upstream: target.provider,
+      error: interrupted ? "client disconnected" : undefined,
       bytesOut,
       inputTokens: traceUsage?.input_tokens || 0,
       outputTokens: traceUsage?.output_tokens || 0,
@@ -1658,7 +1710,7 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
       model: normalizedPayload.model,
       provider: target.provider,
       route: route.reason,
-      status: upstream.status,
+      status: interrupted ? 499 : upstream.status,
       durationMs: Date.now() - startedAt,
       inputTokens: traceUsage?.input_tokens,
       outputTokens: traceUsage?.output_tokens,
@@ -1669,8 +1721,8 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
       threadId,
     });
     return {
-      ok: true,
-      httpStatus: upstream.status,
+      ok: !interrupted,
+      httpStatus: interrupted ? 499 : upstream.status,
       route,
       usage: traceUsage,
       bytesOut,

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -847,10 +847,16 @@ export async function pipeFreeStream(upstreamBody, res, tee, failedMessage, onFi
       settle();
     });
     stream.once("error", settle);
-    res.once("drain", () => outStream?.resume());
-    res.once("finish", () => settle());
-    res.once("error", settle);
+    // "on", not "once": writeOut pauses the upstream on every backpressure event,
+    // so the drain that resumes it must fire every time too. With "once" the second
+    // pause never gets a matching resume and the stream (and the promise) hangs.
+    const onDrain = () => outStream?.resume();
+    res.on("drain", onDrain);
+    const cleanup = () => res.removeListener("drain", onDrain);
+    res.once("finish", () => { cleanup(); settle(); });
+    res.once("error", (error) => { cleanup(); settle(error); });
     res.once("close", () => {
+      cleanup();
       if (!settled) stream.destroy();
       settle();
     });

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -151,6 +151,26 @@ function endRelayStreamFailure(res, message) {
   }
 }
 
+// A stream that already sent headers cannot switch protocols mid-response:
+// terminate in the shape the client was told to expect. Responses SSE streams
+// end with a response.failed event (above); a JSON payload - e.g. the native
+// images endpoints answer application/json - ends with a JSON error object.
+// Writing SSE events into an application/json body leaves the client with a
+// body it cannot parse.
+function endRelayFailure(res, message) {
+  const contentType = String(res.getHeader?.("Content-Type") || "");
+  if (/text\/event-stream/i.test(contentType) || /ndjson|jsonl/i.test(contentType)) {
+    endRelayStreamFailure(res, message);
+    return;
+  }
+  try {
+    res.write(JSON.stringify({ error: { type: "upstream_failed", message } }));
+    res.end();
+  } catch {
+    res.destroy();
+  }
+}
+
 // Headers Codex's signed-in transport sends that the native backend needs.
 // Everything else (tokens for routed providers, loopback bookkeeping) stays out.
 const NATIVE_FORWARD_HEADERS = new Set([
@@ -1052,7 +1072,7 @@ export async function relayNativeImage(payload, res, services, { signal } = {}) 
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: { type: "upstream_failed", message: redactBearer(error.message) } }));
     } else {
-      endRelayStreamFailure(res, redactBearer(error.message));
+      endRelayFailure(res, redactBearer(error.message));
     }
     return { ok: false, httpStatus: 502, error: error.message };
   }

--- a/src/gateway.test.mjs
+++ b/src/gateway.test.mjs
@@ -79,6 +79,9 @@ function responseStub(res) {
     setHeader(name, value) {
       this.headers[name] = value;
     },
+    getHeader(name) {
+      return this.headers[name];
+    },
     flushHeaders() {
       this.headersSent = true;
     },
@@ -452,6 +455,14 @@ test("upstreamTargetFor routes by owning provider", () => {
   assert.equal(ds.model, "deepseek-v4-flash");
   assert.equal(ds.url, "https://api.deepseek.com/responses");
   assert.equal(ds.token, "ds-token");
+
+  // A bare id is a legacy reference and always means the default provider, even
+  // when another profile is active: the picker label said OpenCode Go, so the
+  // billing source must be OpenCode Go too.
+  const legacyUnderDeepseekProfile = upstreamTargetFor({ ...config, profileId: "deepseek-official" }, "deepseek-v4-flash");
+  assert.equal(legacyUnderDeepseekProfile.provider, "opencode-go");
+  assert.equal(legacyUnderDeepseekProfile.url, "https://opencode.ai/zen/go/v1/responses");
+  assert.equal(legacyUnderDeepseekProfile.token, "go-token");
 });
 
 test("upstreamTargetFor routes zen free models to the zen/v1 responses endpoint", () => {
@@ -1051,11 +1062,44 @@ test("relayNativeImage forwards image generation to the native backend", async (
   }
 });
 
+test("relayNativeImage ends a mid-stream upstream failure as JSON, not SSE", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          // A partial image JSON body, then the upstream connection dies.
+          controller.enqueue(Buffer.from('{"data":[{"b64_json":"'));
+          controller.error(new Error("image burst Bearer sk-abc123456"));
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  try {
+    const result = await relayNativeImage(
+      { model: "gpt-image-2", prompt: "boom", size: "1024x1024" },
+      res,
+      { incomingHeaders: {}, requestUrl: "/c/key123/v1/images/generations" },
+    );
+    assert.equal(result.ok, false);
+    const forwarded = Buffer.concat(sink.chunks).toString("utf8");
+    assert.doesNotMatch(forwarded, /event: response\.failed/, "SSE events must not ride in a JSON response");
+    assert.match(forwarded, /"type":"upstream_failed"/);
+    assert.match(forwarded, /image burst/, "the failure reason reaches the client");
+    assert.doesNotMatch(forwarded, /sk-abc123456/, "bearer tokens are redacted");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("legacy provider/model slugs route to us instead of the native backend", async () => {
   const { normalizeLegacySlug } = await import("./gateway.mjs");
-  const known = new Set(["deepseek-v4-flash", "gpt-5.6-luna@opencode-go", "deepseek-v4-flash@deepseek-official"]);
+  const known = new Set(["deepseek-v4-flash@opencode-go", "gpt-5.6-luna@opencode-go", "deepseek-v4-flash@deepseek-official"]);
   // codex-router era merged-catalog ids persisted in old threads:
-  assert.equal(normalizeLegacySlug("opencode-go/deepseek-v4-flash", known), "deepseek-v4-flash");
+  assert.equal(normalizeLegacySlug("opencode-go/deepseek-v4-flash", known), "deepseek-v4-flash@opencode-go");
   assert.equal(normalizeLegacySlug("opencode-go/gpt-5.6-luna", known), "gpt-5.6-luna@opencode-go");
   assert.equal(normalizeLegacySlug("deepseek-official/deepseek-v4-flash", known), "deepseek-v4-flash@deepseek-official");
   // Unknown stays untouched (genuinely native or garbage - upstream decides):

--- a/src/memory.mjs
+++ b/src/memory.mjs
@@ -81,6 +81,11 @@ CREATE TABLE IF NOT EXISTS links (
 `;
 
 const GLOBAL_NODE = "global";
+// Revisions kept per source item before older superseded history is pruned,
+// and the number of memory events retained (both are soft-history limits; the
+// newest data is never touched).
+const MAX_REVISIONS_KEPT = 10;
+const MAX_EVENTS_KEPT = 2000;
 const KNOWN_MEMORY_FILES = [
   { name: "MEMORY.md", trustClass: "trusted_instruction" },
   { name: "memory_summary.md", trustClass: "agent_output" },
@@ -154,7 +159,12 @@ function splitUnits(text) {
 function matchesScope(scopePaths, cwd) {
   const paths = String(scopePaths || "").split("|").filter(Boolean);
   if (!paths.length) return true;
-  return paths.some((scopePath) => scopePath === cwd || cwd.startsWith(`${scopePath}\\`));
+  return paths.some((scopePath) => {
+    const base = String(scopePath);
+    // Scope paths may come from either platform's layout; match both separators
+    // so a POSIX project matches its subdirectories just like a Windows one.
+    return cwd === base || cwd.startsWith(`${base}/`) || cwd.startsWith(`${base}\\`);
+  });
 }
 
 function formatHits(hits) {
@@ -206,7 +216,9 @@ export class MemoryStore {
     if (this.dbs.has(nodeId)) return this.dbs.get(nodeId);
     const file = nodeDbPathFor(this.memoryDir, nodeId);
     if (!create && !existsSync(file)) return null;
-    const db = new DatabaseSync(file);
+    // Wait for the write lock instead of failing immediately when another
+    // process (a second Codex session on the same project) holds it.
+    const db = new DatabaseSync(file, { timeout: 5000 });
     db.exec("PRAGMA journal_mode = WAL");
     db.exec(MEMORY_SCHEMA);
     this.dbs.set(nodeId, db);
@@ -261,54 +273,123 @@ export class MemoryStore {
     const sha = createHash("sha256").update(text).digest("hex");
     const sourceDirAbs = sourceDir ? path.resolve(sourceDir) : "<global>";
     const db = this.#ensureNode(nodeId);
-    const sourceId = stableId("src", adapter, sourceDirAbs);
-    this.#upsert(db, "sources", sourceId, { adapter, native_location: sourceDirAbs, created_at: new Date().toISOString() });
+    // One write transaction per capture: a concurrent second writer (another
+    // session on the same scope) must never observe the "old revision marked
+    // superseded, new one not yet inserted" intermediate state.
+    db.exec("BEGIN IMMEDIATE");
+    let transactionOpen = true;
+    let result;
+    try {
+      const sourceId = stableId("src", adapter, sourceDirAbs);
+      this.#upsert(db, "sources", sourceId, { adapter, native_location: sourceDirAbs, created_at: new Date().toISOString() });
 
-    const itemSeed = itemKey || fileName;
-    const itemId = stableId("item", sourceId, itemSeed);
-    this.#upsert(db, "source_items", itemId, {
-      source_id: sourceId,
-      native_id: itemSeed,
-      path: filePath,
-      kind: adapter === "agent_written" ? "memory" : "file",
-    });
+      const itemSeed = itemKey || fileName;
+      const itemId = stableId("item", sourceId, itemSeed);
+      this.#upsert(db, "source_items", itemId, {
+        source_id: sourceId,
+        native_id: itemSeed,
+        path: filePath,
+        kind: adapter === "agent_written" ? "memory" : "file",
+      });
 
-    const previous = db
-      .prepare("SELECT id, revision, blob_sha256 FROM source_revisions WHERE source_item_id = ? ORDER BY revision DESC LIMIT 1")
-      .get(itemId);
-    if (previous && previous.blob_sha256 === sha) return { skipped: true, revision: previous.revision, sha };
+      const previous = db
+        .prepare("SELECT id, revision, blob_sha256 FROM source_revisions WHERE source_item_id = ? ORDER BY revision DESC LIMIT 1")
+        .get(itemId);
+      if (previous && previous.blob_sha256 === sha) {
+        db.exec("COMMIT");
+        transactionOpen = false;
+        return { skipped: true, revision: previous.revision, sha };
+      }
 
-    const revision = previous ? previous.revision + 1 : 1;
-    const revisionId = stableId("rev", itemId, revision);
-    const observedAt = new Date().toISOString();
-    db
-      .prepare("INSERT INTO source_revisions (id, source_item_id, revision, blob_sha256, size, observed_at, supersedes_revision_id) VALUES (?, ?, ?, ?, ?, ?, ?)")
-      .run(revisionId, itemId, revision, sha, Buffer.byteLength(text), observedAt, previous?.id || null);
-    if (previous) {
-      db.prepare("UPDATE content_units SET memory_state = 'superseded' WHERE source_revision_id = ?").run(previous.id);
+      const revision = previous ? previous.revision + 1 : 1;
+      const revisionId = stableId("rev", itemId, revision);
+      const observedAt = new Date().toISOString();
+      db
+        .prepare("INSERT INTO source_revisions (id, source_item_id, revision, blob_sha256, size, observed_at, supersedes_revision_id) VALUES (?, ?, ?, ?, ?, ?, ?)")
+        .run(revisionId, itemId, revision, sha, Buffer.byteLength(text), observedAt, previous?.id || null);
+      if (previous) {
+        db.prepare("UPDATE content_units SET memory_state = 'superseded' WHERE source_revision_id = ?").run(previous.id);
+      }
+
+      const fileScopes = extractScopes(text);
+      const insertUnit = db.prepare(
+        "INSERT INTO content_units (id, source_revision_id, kind, head, text, text_hash, locator, trust_class, memory_state, scope_paths, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'captured', ?, ?)",
+      );
+      const insertFts = db.prepare("INSERT INTO content_fts (id, head, text) VALUES (?, ?, ?)");
+      const sections = splitUnits(text);
+      let units = 0;
+      sections.forEach((section, index) => {
+        const body = section.body.join("\n").trim();
+        if (!body) return;
+        const unitId = stableId("cu", revisionId, index);
+        const textHash = createHash("sha256").update(body).digest("hex");
+        const locator = JSON.stringify({ source: fileName, heading: section.head, index });
+        const sectionScopes = section.body.some((line) => /applies_to/i.test(line))
+          ? extractScopes(section.body.join("\n"))
+          : fileScopes;
+        insertUnit.run(unitId, revisionId, "section", section.head, body, textHash, locator, trustClass, sectionScopes.join("|"), observedAt);
+        insertFts.run(unitId, section.head || "", body);
+        units += 1;
+      });
+      db.exec("COMMIT");
+      transactionOpen = false;
+      result = { skipped: false, revision, units, sha };
+    } catch (error) {
+      if (transactionOpen) {
+        try { db.exec("ROLLBACK"); } catch { /* preserve the transaction error */ }
+      }
+      throw error;
     }
+    // Pruning is soft maintenance after the durable capture. A busy global event
+    // database must not turn a committed memory write into an apparent failure;
+    // report the deferred maintenance condition to callers instead.
+    try {
+      this.#pruneNode(db);
+    } catch (error) {
+      result.maintenanceError = error.message;
+    }
+    return result;
+  }
 
-    const fileScopes = extractScopes(text);
-    const insertUnit = db.prepare(
-      "INSERT INTO content_units (id, source_revision_id, kind, head, text, text_hash, locator, trust_class, memory_state, scope_paths, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'captured', ?, ?)",
-    );
-    const insertFts = db.prepare("INSERT INTO content_fts (id, head, text) VALUES (?, ?, ?)");
-    const sections = splitUnits(text);
-    let units = 0;
-    sections.forEach((section, index) => {
-      const body = section.body.join("\n").trim();
-      if (!body) return;
-      const unitId = stableId("cu", revisionId, index);
-      const textHash = createHash("sha256").update(body).digest("hex");
-      const locator = JSON.stringify({ source: fileName, heading: section.head, index });
-      const sectionScopes = section.body.some((line) => /applies_to/i.test(line))
-        ? extractScopes(section.body.join("\n"))
-        : fileScopes;
-      insertUnit.run(unitId, revisionId, "section", section.head, body, textHash, locator, trustClass, sectionScopes.join("|"), observedAt);
-      insertFts.run(unitId, section.head || "", body);
-      units += 1;
-    });
-    return { skipped: false, revision, units, sha };
+  // Soft-history limits: drop superseded revisions older than the newest
+  // MAX_REVISIONS_KEPT (with their units and FTS rows) and cap the global
+  // event feed. Runs on every successful write, so the vault never grows
+  // without bound while the recent history stays fully intact.
+  #pruneNode(db) {
+    const pruneRevisions = () => {
+      const old = db
+        .prepare(`
+          SELECT sr.id FROM source_revisions sr
+          WHERE sr.revision <= (
+            SELECT MAX(revision) - ? FROM source_revisions s2 WHERE s2.source_item_id = sr.source_item_id
+          )
+        `)
+        .all(MAX_REVISIONS_KEPT);
+      if (!old.length) return;
+      const unitIds = db.prepare("SELECT id FROM content_units WHERE source_revision_id = ?");
+      const deleteFts = db.prepare("DELETE FROM content_fts WHERE id = ?");
+      const deleteUnit = db.prepare("DELETE FROM content_units WHERE id = ?");
+      const deleteRevision = db.prepare("DELETE FROM source_revisions WHERE id = ?");
+      for (const row of old) {
+        for (const unit of unitIds.all(row.id)) {
+          deleteFts.run(unit.id);
+          deleteUnit.run(unit.id);
+        }
+        deleteRevision.run(row.id);
+      }
+    };
+    db.exec("BEGIN");
+    try {
+      pruneRevisions();
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+    this.#tryEventWrite(() => this.db.exec(`
+      DELETE FROM memory_events
+      WHERE rowid NOT IN (SELECT rowid FROM memory_events ORDER BY rowid DESC LIMIT ${MAX_EVENTS_KEPT})
+    `));
   }
 
   // Explicit write path: the model asks to persist something from the
@@ -572,9 +653,26 @@ export class MemoryStore {
 
   #recordEvent(kind, scope, detail) {
     const id = stableId("evt", kind, scope, detail, Date.now());
-    this.db
-      .prepare("INSERT INTO memory_events (id, kind, scope, detail, created_at) VALUES (?, ?, ?, ?, ?)")
-      .run(id, kind, scope, JSON.stringify(detail), new Date().toISOString());
+    return this.#tryEventWrite(() => {
+      this.db
+        .prepare("INSERT INTO memory_events (id, kind, scope, detail, created_at) VALUES (?, ?, ?, ?, ?)")
+        .run(id, kind, scope, JSON.stringify(detail), new Date().toISOString());
+    });
+  }
+
+  #tryEventWrite(write) {
+    // The event feed is telemetry, not canonical memory. Do not inherit the
+    // five-second canonical-write timeout here: a locked event DB must neither
+    // fail nor delay a completed store/link operation.
+    this.db.exec("PRAGMA busy_timeout = 0");
+    try {
+      write();
+      return true;
+    } catch {
+      return false;
+    } finally {
+      this.db.exec("PRAGMA busy_timeout = 5000");
+    }
   }
 
   // Lightweight event feed for the memory page: newest first.

--- a/src/memory.test.mjs
+++ b/src/memory.test.mjs
@@ -344,6 +344,71 @@ test("search rejects empty queries and punctuation-only input", () => {
   }
 });
 
+test("scope matching covers POSIX subdirectories, not just Windows backslashes", () => {
+  const { dir, memories } = memoryDir();
+  writeFileSync(path.join(memories, "MEMORY.md"), [
+    "# POSIX scoped baseline",
+    "",
+    "scope: posix project.",
+    "applies_to: cwd=/home/dev/stockscan; reuse_rule=current.",
+    "",
+    "## Reusable knowledge",
+    "",
+    "The POSIX project baseline is the stable version.",
+    "",
+  ].join("\n"), "utf8");
+  const store = storeFor(dir);
+  try {
+    store.captureCodexMemories(dir);
+    const hit = store.search({ query: "POSIX project baseline", scopeDir: "/home/dev/stockscan/subdir" });
+    assert.ok(hit.count >= 1, "a project subdirectory should match the parent scope");
+    assert.match(hit.text, /POSIX project baseline/);
+  } finally {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("old superseded revisions are pruned while the newest history survives", () => {
+  const { dir } = memoryDir();
+  const store = storeFor(dir);
+  try {
+    for (let i = 1; i <= 12; i += 1) {
+      store.storeMemory({ content: `token${i} baseline`, key: "entry-key" });
+    }
+    const status = store.status();
+    assert.equal(status.source_revisions, 10, "only the newest MAX_REVISIONS_KEPT revisions remain");
+    const hit = store.search({ query: "token12 baseline" });
+    assert.equal(hit.count, 1, "the newest revision is still recallable");
+    const older = store.search({ query: "token1" });
+    assert.equal(older.count, 0, "pruned superseded revisions are gone from recall");
+  } finally {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("post-commit maintenance contention does not report a committed store as failed", () => {
+  const { dir } = memoryDir();
+  const store = storeFor(dir);
+  const globalFile = nodeDbPathFor(path.join(dir, "vault"), "global");
+  const lock = new DatabaseSync(globalFile);
+  try {
+    lock.exec("BEGIN EXCLUSIVE");
+    const startedAt = Date.now();
+    const result = store.storeMemory({ content: "committed under event contention", scopeDir: "D:/project", key: "locked-event" });
+    assert.equal(result.ok, true);
+    assert.ok(Date.now() - startedAt < 2000, "soft event maintenance must not wait for the canonical-write busy timeout");
+    const project = store.nodeDb(scopeNodeId("D:/project"));
+    assert.equal(project.prepare("SELECT COUNT(*) AS n FROM source_revisions").get().n, 1, "the capture was committed");
+  } finally {
+    try { lock.exec("ROLLBACK"); } catch { /* already released */ }
+    lock.close();
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("stores project memories in independent nodes and exposes node aggregates", () => {
   const { dir } = memoryDir();
   const store = storeFor(dir);

--- a/src/native-catalog.mjs
+++ b/src/native-catalog.mjs
@@ -1,7 +1,13 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
+
+// Async exec so the model-refresh timer and startup capture never block the event
+// loop of a live relay: `codex debug models` can take seconds (or hang to its
+// timeout), and a synchronous call would stall every in-flight SSE stream.
+const execFileAsync = promisify(execFile);
 
 // The Codex App's picker list is a replacement, not a merge: with
 // `model_catalog_json` set it shows exactly that file, otherwise it shows the
@@ -53,35 +59,36 @@ function desktopBundledCodex() {
   return desktopCodexCandidates().find((candidate) => existsSync(candidate)) || null;
 }
 
-function pathCodex() {
+async function pathCodex() {
   if (process.platform === "win32") return null;
   try {
-    const output = execFileSync("which", ["codex"], {
+    const { stdout } = await execFileAsync("which", ["codex"], {
       encoding: "utf8",
       timeout: 5_000,
       windowsHide: true,
     });
-    const candidate = String(output || "").trim().split(/\r?\n/)[0];
+    const candidate = String(stdout || "").trim().split(/\r?\n/)[0];
     return candidate && existsSync(candidate) ? candidate : null;
   } catch {
     return null;
   }
 }
 
-function resolveCodexBinary() {
+async function resolveCodexBinary() {
   if (process.env.CODEX_BIN && existsSync(process.env.CODEX_BIN)) return process.env.CODEX_BIN;
-  return desktopBundledCodex() || pathCodex();
+  return desktopBundledCodex() || (await pathCodex());
 }
 
-function runCodex(args) {
-  const binary = resolveCodexBinary();
+async function runCodex(args, timeout = 30_000) {
+  const binary = await resolveCodexBinary();
   if (!binary) return null;
-  return execFileSync(binary, args, {
+  const { stdout } = await execFileAsync(binary, args, {
     encoding: "utf8",
-    timeout: 30_000,
+    timeout,
     maxBuffer: 64 * 1024 * 1024,
     windowsHide: true,
   });
+  return stdout;
 }
 
 export function nativeCatalogPath(config) {
@@ -116,9 +123,9 @@ export function nativeModelSlugs(config) {
   return slugs;
 }
 
-export function codexVersion() {
+export async function codexVersion() {
   try {
-    const out = runCodex(["--version"]);
+    const out = await runCodex(["--version"], 5_000);
     return String(out || "").trim().split(/\s+/)[0] || "";
   } catch {
     return "";
@@ -130,9 +137,9 @@ export function codexVersion() {
 // next refresh. Returns the captured models, or null when the CLI is missing
 // or the capture failed (the catalog then simply keeps the last good cache).
 export async function refreshNativeCatalog(config) {
-  if (!resolveCodexBinary()) return null;
+  if (!(await resolveCodexBinary())) return null;
   try {
-    const output = runCodex(["debug", "models", "--bundled"]);
+    const output = await runCodex(["debug", "models", "--bundled"]);
     const parsed = JSON.parse(output);
     if (!Array.isArray(parsed?.models) || parsed.models.length === 0) return null;
     const file = nativeCatalogPath(config);
@@ -140,7 +147,7 @@ export async function refreshNativeCatalog(config) {
     const temporary = `${file}.tmp.${process.pid}`;
     writeFileSync(
       temporary,
-      JSON.stringify({ captured_with: codexVersion(), models: parsed.models }, null, 2),
+      JSON.stringify({ captured_with: await codexVersion(), models: parsed.models }, null, 2),
       "utf8",
     );
     renameSync(temporary, file);

--- a/src/profiles.mjs
+++ b/src/profiles.mjs
@@ -89,7 +89,10 @@ function catalogEntry({ slug, displayName, description, compHash, inputModalitie
   };
 }
 
-function modelCatalogDefaults({ mainModel, displayName, description, compHash, inputModalities, supportsSearchTool, baseInstructions, defaultReasoningLevel = "high", supportedReasoningLevels = [ { effort: "low", description: "Fast responses with lighter reasoning" }, { effort: "high", description: "Deeper reasoning for complex work" }, { effort: "xhigh", description: "Extra-deep reasoning for hard problems" } ], availableModels = [] }) {
+function modelCatalogDefaults({ profileId, mainModel, displayName, description, compHash, inputModalities, supportsSearchTool, baseInstructions, defaultReasoningLevel = "high", supportedReasoningLevels = [ { effort: "low", description: "Fast responses with lighter reasoning" }, { effort: "high", description: "Deeper reasoning for complex work" }, { effort: "xhigh", description: "Extra-deep reasoning for hard problems" } ], availableModels = [] }) {
+  // The main entry is owner-qualified like every other published entry, even when
+  // the caller passed a bare reference (a legacy .env or a test fixture).
+  const qualifiedMain = publishedSlugFor(profileId, mainModel);
   const base = { compHash, supportsSearchTool, baseInstructions, defaultReasoningLevel, supportedReasoningLevels };
   // The selected main model may belong to a provider other than the active
   // profile (e.g. a dashboard-added custom endpoint set as main). Label its
@@ -117,7 +120,7 @@ function modelCatalogDefaults({ mainModel, displayName, description, compHash, i
     for (const model of profile.availableModels || []) {
       if (!model?.id || model.status === "unavailable") continue;
       const slug = publishedSlugFor(entry.id, model);
-      if (slug === mainModel || rest.some((m) => m.slug === slug)) continue;
+      if (slug === qualifiedMain || rest.some((m) => m.slug === slug)) continue;
       rest.push({
         slug,
         displayName: `${entry.label} - ${model.label || model.id}`,
@@ -129,7 +132,7 @@ function modelCatalogDefaults({ mainModel, displayName, description, compHash, i
   }
   return {
     models: [
-      catalogEntry({ ...base, slug: mainModel, displayName: ownerQualifiedDisplayName(mainModel) || displayName, description, inputModalities, priority: 1, contextWindow: contextWindowFor(mainModel) }),
+      catalogEntry({ ...base, slug: qualifiedMain, displayName: ownerQualifiedDisplayName(qualifiedMain) || displayName, description, inputModalities, priority: 1, contextWindow: contextWindowFor(qualifiedMain) }),
       ...rest.map((model, index) => catalogEntry({
         ...base,
         slug: model.slug,
@@ -199,6 +202,7 @@ const OPENCODE_GO_PROFILE = {
 
   modelCatalog({ mainModel, visionModel, baseInstructions }) {
     return modelCatalogDefaults({
+      profileId: OPENCODE_GO_PROFILE.id,
       mainModel,
       // The same "Provider - Model" label the rest of the catalog uses, so the
       // main entry does not render differently in the App picker.
@@ -241,6 +245,7 @@ const DEEPSEEK_OFFICIAL_PROFILE = {
 
   modelCatalog({ mainModel, baseInstructions }) {
     return modelCatalogDefaults({
+      profileId: DEEPSEEK_OFFICIAL_PROFILE.id,
       mainModel,
       displayName: "DeepSeek V4 (Official)",
       description: "DeepSeek official Responses endpoint through ModelDock.",
@@ -272,6 +277,7 @@ const CUSTOM_PROFILE = {
   availableModels: [],
   modelCatalog({ mainModel, baseInstructions }) {
     return modelCatalogDefaults({
+      profileId: CUSTOM_PROFILE.id,
       mainModel,
       displayName: "Custom endpoint",
       description: "User-configured custom Responses endpoint through ModelDock.",
@@ -333,20 +339,20 @@ export const PROVIDER_SEPARATOR = "@";
 // keep resolving without a suffix.
 const DEFAULT_PROFILE_ID = "opencode-go";
 
-// The slug under which a model id is published in the Codex catalog. Bare ids stay
-// with the default profile so existing Codex configs keep resolving; a duplicate in
-// another provider, or a model whose bare id must stay reserved (gpt-5.6-luna is
-// also a native GPT picker slot), carries the @provider suffix. Accepts either a
-// profile model object or a bare id string, so the catalog builder and config
-// loading share one rule.
+// The slug under which a model id is published in the Codex catalog. Every model a
+// profile owns is published owner-qualified: the @provider suffix is a routing
+// address that names the upstream, so the picker label, the catalog grouping, and
+// the route can never disagree about which provider a model belongs to. A bare id
+// survives only as a legacy reference (an older config.toml or a stored thread
+// selection): it is never published and routes to the default provider (see
+// providerForModel). Accepts either a profile model object or a bare id string, so
+// the catalog builder and config loading share one rule.
 export function publishedSlugFor(profileId, model) {
   const id = typeof model === "string" ? model : model?.id;
   if (!id) return model;
-  const entry = profileById(profileId || DEFAULT_PROFILE_ID).availableModels?.find((candidate) => candidate.id === id);
-  const ownerQualified = Boolean(entry?.ownerQualified || (typeof model === "object" && model?.ownerQualified));
-  const owned = profileId !== DEFAULT_PROFILE_ID
-    && (profileById(DEFAULT_PROFILE_ID).availableModels || []).some((candidate) => candidate.id === id);
-  return owned || ownerQualified ? `${id}${PROVIDER_SEPARATOR}${profileId || DEFAULT_PROFILE_ID}` : id;
+  const pid = profileId || DEFAULT_PROFILE_ID;
+  const owned = profileById(pid).availableModels?.some((candidate) => candidate.id === id);
+  return owned ? `${id}${PROVIDER_SEPARATOR}${pid}` : id;
 }
 
 export function bareModelId(model) {
@@ -362,33 +368,26 @@ export function providerForModel(config, model) {
     const tagged = String(model).slice(at + 1);
     if (PROFILES[tagged]) return tagged;
   }
-  // Resolve the active profile by id when the caller passed a partial object: several
-  // ids (deepseek-v4-flash, deepseek-v4-pro) exist in more than one catalog, and the
-  // active profile is what breaks the tie - a stub without availableModels would
-  // silently lose that tie-break and hand the model to the wrong provider.
-  const passed = config?.profile;
-  const current = passed?.availableModels
-    ? passed
-    : profileById(passed?.id || config?.profileId || "") || passed || null;
-  if (current?.availableModels?.some((entry) => entry.id === model)) return current.id;
-  for (const entry of profileOptions()) {
-    const candidate = profileById(entry.id);
-    if (candidate.availableModels?.some((modelEntry) => modelEntry.id === model)) return candidate.id;
-  }
-  return config?.profileId || "opencode-go";
+  // Bare id: legacy compatibility only. Bare ids were never published by any
+  // provider other than the default one, so a bare id left over from an older
+  // config or a stored thread selection routes there unconditionally instead of
+  // to the currently active profile - the picker label and the billing source
+  // must never disagree.
+  return DEFAULT_PROFILE_ID;
 }
 
 // Resolve the curated model entry (label, endpoint, zen flag, vision metadata) for a
 // bare model id. Used by the gateway to pick the upstream base URL per model.
 export function modelEntryFor(config, model) {
   const provider = providerForModel(config, model);
+  const bare = bareModelId(model);
+  const owned = profileById(provider).availableModels?.find((entry) => entry.id === bare);
+  if (owned) return owned;
   const passed = config?.profile;
   const current = passed?.availableModels
     ? passed
     : profileById(passed?.id || config?.profileId || "") || passed || null;
-  const found = current?.availableModels?.find((entry) => entry.id === model)
-    || profileById(provider).availableModels?.find((entry) => entry.id === model);
-  return found || null;
+  return current?.availableModels?.find((entry) => entry.id === bare) || null;
 }
 
 export function tokenFor(config, model) {

--- a/src/profiles.test.mjs
+++ b/src/profiles.test.mjs
@@ -12,17 +12,18 @@ import {
   AUTO_COMPACT_TOKEN_LIMIT,
 } from "./profiles.mjs";
 
-test("publishedSlugFor keeps bare ids unless a collision needs the provider suffix", () => {
+test("publishedSlugFor owner-qualifies every owned model", () => {
   const luna = OPENCODE_GO_PROFILE.availableModels.find((model) => model.id === "gpt-5.6-luna");
   assert.equal(luna.ownerQualified, true, "our Luna must stay out of the bare native gpt-5.6-luna slot");
   assert.equal(publishedSlugFor("opencode-go", luna), "gpt-5.6-luna@opencode-go");
   assert.equal(publishedSlugFor("opencode-go", "gpt-5.6-luna"), "gpt-5.6-luna@opencode-go", "string ids resolve through the profile entry too");
-  assert.equal(publishedSlugFor("opencode-go", "deepseek-v4-flash"), "deepseek-v4-flash");
+  assert.equal(publishedSlugFor("opencode-go", "deepseek-v4-flash"), "deepseek-v4-flash@opencode-go", "the default provider qualifies its own models too");
   assert.equal(
     publishedSlugFor("deepseek-official", "deepseek-v4-flash"),
     "deepseek-v4-flash@deepseek-official",
     "a duplicate in another provider is owner-qualified",
   );
+  assert.equal(publishedSlugFor("opencode-go", "gpt-5.6-sol"), "gpt-5.6-sol", "an id no profile owns passes through untouched (native GPT)");
 });
 
 test("exposes every registered profile through the registry", () => {
@@ -72,7 +73,7 @@ test("model catalog is generated per profile with distinct comp hashes", () => {
   const goCatalog = OPENCODE_GO_PROFILE.modelCatalog({ mainModel: "deepseek-v4-flash", visionModel: "gpt-5.6-luna", baseInstructions: instructions });
   const officialCatalog = DEEPSEEK_OFFICIAL_PROFILE.modelCatalog({ mainModel: "deepseek-v4-flash", baseInstructions: instructions });
   assert.ok(goCatalog.models.length >= 1, "catalog includes the main model plus every available model");
-  assert.equal(goCatalog.models[0].slug, "deepseek-v4-flash");
+  assert.equal(goCatalog.models[0].slug, "deepseek-v4-flash@opencode-go");
   assert.equal(goCatalog.models[0].comp_hash, "modeldock-opencode-go-v1");
   assert.equal(goCatalog.models[0].supports_search_tool, false);
   assert.equal(goCatalog.models[0].default_reasoning_level, "high");

--- a/src/server-gateway.test.mjs
+++ b/src/server-gateway.test.mjs
@@ -297,6 +297,7 @@ test("gateway: historical images are replaced with refs, current images stay for
 });
 
 test("caller-key routes: correct key relays, wrong key and enforced bare path 401", async (t) => {
+  const zlib = await import("node:zlib");
   const upstream = createServer((req, res) => {
     res.setHeader("content-type", "text/event-stream");
     res.end('data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\ndata: [DONE]\n\n');
@@ -314,6 +315,12 @@ test("caller-key routes: correct key relays, wrong key and enforced bare path 40
 
   const wrong = await fetch(`${instance.base}/c/wrong-key-00000000000000000000000/v1/responses`, { method: "POST", headers, body });
   assert.equal(wrong.status, 401, "a wrong key is rejected");
+  const wrongCompressed = await fetch(`${instance.base}/c/wrong-key-00000000000000000000000/v1/responses`, {
+    method: "POST",
+    headers: { ...headers, "content-encoding": "zstd" },
+    body: zlib.zstdCompressSync(Buffer.from(body)),
+  });
+  assert.equal(wrongCompressed.status, 401, "a wrong key is rejected before zstd decompression");
 
   const models = await fetch(`${instance.base}/c/test-caller-key-0123456789abcdefghij/v1/models`);
   assert.equal(models.status, 200, "the keyed models path serves the catalog");
@@ -322,6 +329,12 @@ test("caller-key routes: correct key relays, wrong key and enforced bare path 40
   t.after(() => { process.env.MODELDOCK_REQUIRE_CALLER_KEY = "0"; });
   const bare = await fetch(`${instance.base}/v1/responses`, { method: "POST", headers, body });
   assert.equal(bare.status, 401, "bare path is refused once enforcement is on");
+  const bareCompressed = await fetch(`${instance.base}/v1/responses`, {
+    method: "POST",
+    headers: { ...headers, "content-encoding": "zstd" },
+    body: zlib.zstdCompressSync(Buffer.from(body)),
+  });
+  assert.equal(bareCompressed.status, 401, "compressed bare path is refused before decompression");
 });
 
 test("caller-key enforcement defaults to on: bare paths 401 without an explicit opt-out", async (t) => {
@@ -465,7 +478,7 @@ test("gateway: nativeMerge=false hides native models from /v1/models but the rel
 
   const models = await (await fetch(`${instance.base}/v1/models`)).json();
   const slugs = models.models.map((model) => model.slug);
-  assert.ok(slugs.includes("deepseek-v4-flash"), "curated Go models stay published");
+  assert.ok(slugs.includes("deepseek-v4-flash@opencode-go"), "curated Go models stay published");
   assert.ok(slugs.includes("gpt-5.6-luna@opencode-go"), "our qualified Luna stays published");
   assert.ok(!slugs.includes("gpt-5.6-luna"), "the native GPT model is hidden for non-subscribers");
 
@@ -504,7 +517,7 @@ test("gateway: trial mode serves only the free pair and relays zen-free models t
   t.after(instance.stop);
 
   const models = await (await fetch(`${instance.base}/v1/models`)).json();
-  assert.deepEqual(models.models.map((model) => model.slug).sort(), ["deepseek-v4-flash-free", "mimo-v2.5-free"]);
+  assert.deepEqual(models.models.map((model) => model.slug).sort(), ["deepseek-v4-flash-free@opencode-go", "mimo-v2.5-free@opencode-go"]);
 
   const relay = await fetch(`${instance.base}/v1/responses`, {
     method: "POST",

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1,6 +1,6 @@
 import path from "node:path";
 import os from "node:os";
-import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdirSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import express from "express";
@@ -303,6 +303,28 @@ function configMutationGuard(config) {
     }
     if (!req.is("application/json")) {
       return res.status(415).json({ error: { type: "content_type_required", message: "Config changes require application/json." } });
+    }
+    return next();
+  };
+}
+
+// The MCP tool endpoint is reached by Codex / the stdio bridge, which are not
+// browsers and send no Origin header. Reject any request that DOES carry a
+// cross-origin Origin so a malicious web page (or a DNS-rebinding attack that
+// makes itself same-host) cannot drive vision_inspect/speak against this loopback
+// gateway. A full caller-key on /mcp would also stop non-browser local processes;
+// that is a larger change (the base URL written into config.toml would have to
+// carry the key) and is tracked separately.
+function crossOriginGuard(config) {
+  const allowedOrigins = new Set([
+    `http://${urlHost(config.host)}:${config.port}`,
+    `http://127.0.0.1:${config.port}`,
+    `http://localhost:${config.port}`,
+  ]);
+  return (req, res, next) => {
+    const origin = req.get("origin");
+    if (origin && !allowedOrigins.has(origin)) {
+      return res.status(403).json({ error: { type: "origin_not_allowed", message: "Cross-origin requests are not allowed on this endpoint." } });
     }
     return next();
   };
@@ -715,7 +737,12 @@ export function createServices(config = loadConfig()) {
         visionModel: modelSelection.visionModel,
       });
       mkdirSync(path.dirname(catalogFile), { recursive: true });
-      writeFileSync(catalogFile, JSON.stringify(catalog, null, 2), "utf8");
+      // Atomic replace: Codex reads this file on its own schedule, so a
+      // half-written JSON must never be observable. Same-directory rename is
+      // atomic on both Windows and POSIX.
+      const tmp = `${catalogFile}.${process.pid}.tmp`;
+      writeFileSync(tmp, JSON.stringify(catalog, null, 2), "utf8");
+      renameSync(tmp, catalogFile);
       return catalog.models?.length || 0;
     } catch (error) {
       console.log(`[gate] model catalog file write failed: ${error.message}`);
@@ -767,14 +794,35 @@ export function createServices(config = loadConfig()) {
 // pre-set req.body, so this outer middleware drains + decompresses zstd bodies
 // itself and hands the parsed JSON through. gzip/deflate/br stay with
 // body-parser, which supports them natively.
-function zstdRequestDecoder() {
-  const canZstd = typeof zlib.zstdDecompressSync === "function";
+function isCallerKeyEnforced() {
+  const raw = String(process.env.MODELDOCK_REQUIRE_CALLER_KEY || "").toLowerCase();
+  return raw === "" || !["0", "false", "off"].includes(raw);
+}
+
+function protectedRelayPath(pathname) {
+  return pathname === "/v1/responses"
+    || pathname === "/responses"
+    || pathname === "/v1/responses/compact"
+    || pathname === "/responses/compact"
+    || [...NATIVE_IMAGE_PATHS].includes(pathname);
+}
+
+function zstdRequestDecoder(callerKey) {
+  const canZstd = typeof zlib.zstdDecompress === "function";
   const maxInput = 16 * 1024 * 1024;
   const maxOutput = 64 * 1024 * 1024;
   return (req, res, next) => {
     if (String(req.headers["content-encoding"] || "").toLowerCase() !== "zstd") return next();
     if (!canZstd) {
       return res.status(415).json({ error: { type: "unsupported_encoding", message: "zstd request bodies require Node 23.8+ (run ModelDock on Node 24)." } });
+    }
+    const pathname = String(req.url || "").split("?", 1)[0];
+    const keyMatch = pathname.match(/^\/c\/([^/]+)/);
+    if (keyMatch && (!callerKey || !callerKeyEqual(keyMatch[1], callerKey))) {
+      return res.status(401).json({ error: { type: "invalid_caller_key", message: "Unknown caller key." } });
+    }
+    if (!keyMatch && protectedRelayPath(pathname) && isCallerKeyEnforced()) {
+      return res.status(401).json({ error: { type: "caller_key_required", message: "This gateway requires the keyed base URL." } });
     }
     const chunks = [];
     let received = 0;
@@ -792,18 +840,22 @@ function zstdRequestDecoder() {
     req.on("error", next);
     req.on("end", () => {
       if (tooLarge) return;
-      try {
-        const body = zlib.zstdDecompressSync(Buffer.concat(chunks));
-        if (body.length > maxOutput) {
-          return res.status(413).json({ error: { type: "payload_too_large", message: `zstd request decompresses beyond the ${maxOutput}-byte limit` } });
+      zlib.zstdDecompress(Buffer.concat(chunks), { maxOutputLength: maxOutput }, (error, body) => {
+        if (error) {
+          if (error.code === "ERR_BUFFER_TOO_LARGE") {
+            return res.status(413).json({ error: { type: "payload_too_large", message: `zstd request decompresses beyond the ${maxOutput}-byte limit` } });
+          }
+          return res.status(400).json({ error: { type: "bad_request", message: `zstd request decode failed: ${error.message}` } });
         }
-        req.headers["content-encoding"] = "identity";
-        req.headers["content-length"] = String(body.length);
-        req.body = JSON.parse(body.toString("utf8"));
-        next();
-      } catch (error) {
-        res.status(400).json({ error: { type: "bad_request", message: `zstd request decode failed: ${error.message}` } });
-      }
+        try {
+          req.headers["content-encoding"] = "identity";
+          req.headers["content-length"] = String(body.length);
+          req.body = JSON.parse(body.toString("utf8"));
+          next();
+        } catch (decodeError) {
+          res.status(400).json({ error: { type: "bad_request", message: `zstd request decode failed: ${decodeError.message}` } });
+        }
+      });
     });
   };
 }
@@ -829,7 +881,7 @@ export function createApp(services = createServices()) {
     },
   });
 
-  app.all("/mcp", (req, res) => mcpHandler(req, res, req.body));
+  app.all("/mcp", crossOriginGuard(config), (req, res) => mcpHandler(req, res, req.body));
   // Capability-key routes: the base_url written into config.toml carries the key
   // (/c/<key>/v1), so Codex authenticates implicitly while a hostile local web
   // page (which can POST to loopback but cannot read ~/.modeldock) cannot.
@@ -855,8 +907,7 @@ export function createApp(services = createServices()) {
   // the upstream tokens this process holds. MODELDOCK_REQUIRE_CALLER_KEY=0 (or
   // off/false) re-opens the bare paths for legacy configs.
   const callerKeyEnforced = () => {
-    const raw = String(process.env.MODELDOCK_REQUIRE_CALLER_KEY || "").toLowerCase();
-    return raw === "" || !["0", "false", "off"].includes(raw);
+    return isCallerKeyEnforced();
   };
   const bareRelay = (req, res) => {
     if (callerKeyEnforced()) {
@@ -1268,7 +1319,7 @@ export function createApp(services = createServices()) {
   // (which is registered inside createMcpExpressApp and cannot be reordered).
   const outer = express();
   outer.disable("x-powered-by");
-  outer.use(zstdRequestDecoder());
+  outer.use(zstdRequestDecoder(services.callerKey));
   outer.use(app);
   return { app: outer, close: () => mcpHandler.close?.(), services };
 }

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -680,7 +680,9 @@ export function createServices(config = loadConfig()) {
   });
   const autostart = createAutostart();
   autostart.refresh().catch(() => {});
-  const updater = createUpdater();
+  // Re-check periodically so the Update button stays current without a restart;
+  // the check is fire-and-forget and costs one small API call every 6h.
+  const updater = createUpdater({ autoCheckMs: 6 * 60 * 60 * 1000 });
   updater.check().catch(() => {});
   const routeAffinity = new RouteAffinity();
   const runtime = { profile: mutableConfig.profile, profileId: mutableConfig.profileId };

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -455,6 +455,16 @@ async function probeImageSupport(modelId, config) {
 // image escalation, affinity).
 async function relayGatewayRequest(req, res, services) {
   const { config, metrics, mediaStore, routeAffinity, modelSelection } = services;
+  // Abort the upstream call when Codex disconnects (user hits stop, or its own
+  // timeout fires). Without this, a client that drops during the pre-first-byte
+  // "thinking" wait or a buffered leg (compaction arrayBuffer, free non-stream
+  // text) leaves the upstream fetch running to completion - burning tokens - and
+  // Codex's retry then issues a duplicate. The streaming leg already tears down
+  // on res "close"; the signal covers the phases before/around it.
+  const controller = new AbortController();
+  res.on("close", () => {
+    if (!res.writableFinished) controller.abort();
+  });
   const result = await relayGatewayResponses(req.body, res, {
     config,
     metrics,
@@ -467,6 +477,7 @@ async function relayGatewayRequest(req, res, services) {
     // The native passthrough leg forwards these to ChatGPT's backend untouched.
     incomingHeaders: req.headers,
     requestUrl: req.originalUrl,
+    signal: controller.signal,
   });
   if (result?.route?.reason === "client_selected" && modelSelection && result.route.model !== modelSelection.mainModel) {
     modelSelection.mainModel = result.route.model;

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -106,14 +106,29 @@ function withTierLabel(model) {
   return decorated;
 }
 
-// The slugs the Codex catalog publishes: every provider's models, with the owner suffix
-// where a bare id would be ambiguous. Used to decide whether a client-chosen model is
-// one this gate can actually serve.
+// Bare ids an older install could still reference: every model the default
+// provider (opencode-go) owns that is not a reserved native slot. gpt-5.6-luna is
+// excluded because its bare id belongs to the native GPT pipeline, not to us.
+function legacyBareIds(config) {
+  const ids = new Set();
+  const defaultProfile = profileById("opencode-go");
+  for (const model of defaultProfile?.availableModels || []) {
+    if (model?.id && !model.ownerQualified && model.status !== "unavailable") ids.add(model.id);
+  }
+  return ids;
+}
+
+// The slugs this gate can serve: every provider's published catalog plus the
+// legacy bare ids above. Used to decide whether a client-chosen model is one this
+// gate can route (anything else is native GPT traffic). The legacy bare ids keep
+// an old thread selection on the routed path (providerForModel sends it to
+// opencode-go) instead of letting isNativeModel misroute it to ChatGPT.
 function publishedModelIds(config) {
   const ids = new Set();
   for (const model of codexModelCatalog(config).models || []) {
     if (model?.slug) ids.add(model.slug);
   }
+  for (const id of legacyBareIds(config)) ids.add(id);
   return ids;
 }
 
@@ -1017,13 +1032,19 @@ export function createApp(services = createServices()) {
           result = await configSwitcher.enable();
           if (mode === "trial") {
             config.trialMode = true;
-            services.modelSelection.mainModel = TRIAL_MAIN_MODEL;
-            services.modelSelection.visionModel = TRIAL_VISION_MODEL;
-            services.configSwitcher.model = TRIAL_MAIN_MODEL;
+            // The catalog is fully owner-qualified, so the selected pair is
+            // stored and persisted in its published form too - a bare trial id
+            // would make the dashboard selected value disagree with the picker
+            // until the next restart.
+            const trialMain = publishedSlugFor(config.profileId, TRIAL_MAIN_MODEL);
+            const trialVision = publishedSlugFor(config.profileId, TRIAL_VISION_MODEL);
+            services.modelSelection.mainModel = trialMain;
+            services.modelSelection.visionModel = trialVision;
+            services.configSwitcher.model = trialMain;
             const trialEnv = {
               MODELDOCK_TRIAL: "1",
-              MODELDOCK_MAIN_MODEL: TRIAL_MAIN_MODEL,
-              MODELDOCK_VISION_MODEL: TRIAL_VISION_MODEL,
+              MODELDOCK_MAIN_MODEL: trialMain,
+              MODELDOCK_VISION_MODEL: trialVision,
             };
             if (nativeMerge !== undefined) trialEnv.MODELDOCK_NATIVE_MERGE = nativeMerge ? "1" : "0";
             writeEnvFile(trialEnv, config.envFile);
@@ -1085,14 +1106,18 @@ export function createApp(services = createServices()) {
   app.get("/api/profiles", (req, res) => res.json({ selected: config.profileId, options: profileOptions() }));
   app.post("/api/models", mutateConfig, (req, res) => {
     const current = services.modelSelection;
-    let nextMain = req.body?.mainModel === undefined ? current.mainModel : req.body.mainModel;
-    let nextVision = req.body?.visionModel === undefined ? current.visionModel : req.body.visionModel;
+    // Resolve a bare id to its published form first: the options list is fully
+    // owner-qualified, so a legacy/dashboard submission of "kimi-k2.5" must match
+    // the "kimi-k2.5@opencode-go" entry instead of 400ing on an exact-id lookup.
+    const qualify = (id) => publishedSlugFor(config.profileId, id);
+    let nextMain = qualify(req.body?.mainModel === undefined ? current.mainModel : req.body.mainModel);
+    let nextVision = qualify(req.body?.visionModel === undefined ? current.visionModel : req.body.visionModel);
     const nextProvider = req.body?.provider;
     // Trial mode pins the free pair and the opencode-go provider; only the mode
     // switch can move models while it is active.
     if (config.trialMode) {
-      nextMain = TRIAL_MAIN_MODEL;
-      nextVision = TRIAL_VISION_MODEL;
+      nextMain = qualify(TRIAL_MAIN_MODEL);
+      nextVision = qualify(TRIAL_VISION_MODEL);
     }
     if (!config.trialMode && nextProvider !== undefined && nextProvider !== config.profileId) {
       const known = profileOptions().some((entry) => entry.id === nextProvider);

--- a/src/server.test.mjs
+++ b/src/server.test.mjs
@@ -95,7 +95,7 @@ test("without token: healthz and responses return 503, local models catalog stil
   assert.equal((await fetch(`${instance.base}/healthz`)).status, 503);
   const models = await fetch(`${instance.base}/v1/models`);
   assert.equal(models.status, 200, "models catalog is local and does not need the token");
-  assert.equal((await models.json()).models[0].slug, "deepseek-v4-flash");
+  assert.equal((await models.json()).models[0].slug, "deepseek-v4-flash@opencode-go");
   const responses = await fetch(`${instance.base}/v1/responses`, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -145,10 +145,10 @@ test("model API exposes selectable main and vision-capable options", async (t) =
   t.after(instance.stop);
   const initial = await (await fetch(`${instance.base}/api/models`)).json();
   assert.equal(initial.selected.mainModel, "deepseek-v4-flash");
-  assert.deepEqual(initial.options.filter((model) => model.supportsVision).map((model) => model.id), ["gpt-5.6-luna@opencode-go", "grok-4.5", "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "mimo-v2.5", "mimo-v2.5-free"]);
+  assert.deepEqual(initial.options.filter((model) => model.supportsVision).map((model) => model.id), ["gpt-5.6-luna@opencode-go", "grok-4.5@opencode-go", "kimi-k2.5@opencode-go", "kimi-k2.6@opencode-go", "kimi-k2.7-code@opencode-go", "mimo-v2.5@opencode-go", "mimo-v2.5-free@opencode-go"]);
   const changed = await fetch(`${instance.base}/api/models`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ mainModel: "gpt-5.6-luna@opencode-go", visionModel: "kimi-k2.5" }) });
   assert.equal(changed.status, 200);
-  assert.deepEqual((await changed.json()).selected, { mainModel: "gpt-5.6-luna@opencode-go", visionModel: "kimi-k2.5" });
+  assert.deepEqual((await changed.json()).selected, { mainModel: "gpt-5.6-luna@opencode-go", visionModel: "kimi-k2.5@opencode-go" });
   const invalid = await fetch(`${instance.base}/api/models`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ visionModel: "deepseek-v4-flash" }) });
   assert.equal(invalid.status, 400);
 });
@@ -159,7 +159,7 @@ test("models endpoint serves the local Codex catalog", async (t) => {
   const response = await fetch(`${instance.base}/v1/models`);
   assert.equal(response.status, 200);
   const body = await response.json();
-  assert.equal(body.models[0].slug, "deepseek-v4-flash");
+  assert.equal(body.models[0].slug, "deepseek-v4-flash@opencode-go");
   assert.equal(body.models[0].supports_parallel_tool_calls, false);
   assert.deepEqual(body.models[0].supported_reasoning_levels.map((level) => level.effort), ["low", "high", "xhigh"]);
   assert.match(body.models[0].base_instructions, /coding agent/);
@@ -174,7 +174,7 @@ test("codexModelCatalog matches Codex schema requirements", () => {
     nativeCatalogFile: path.join(os.tmpdir(), "modeldock-test-native-missing.json"),
   });
   const model = catalog.models[0];
-  assert.equal(model.slug, "deepseek-v4-flash");
+  assert.equal(model.slug, "deepseek-v4-flash@opencode-go");
   assert.equal(model.supports_reasoning_summaries, true);
   assert.equal(model.model_messages.instructions_variables.personality_pragmatic, "");
   assert.equal(model.apply_patch_tool_type, "freeform");
@@ -255,13 +255,13 @@ test("config mode endpoint switches OFF / TRIAL / ON and locks the free pair in 
   assert.equal(trial.enabled, true);
   assert.equal(trial.trial, true);
   assert.equal(trial.restartRequired, true);
-  assert.equal(instance.services.modelSelection.mainModel, "deepseek-v4-flash-free");
-  assert.equal(instance.services.modelSelection.visionModel, "mimo-v2.5-free");
+  assert.equal(instance.services.modelSelection.mainModel, "deepseek-v4-flash-free@opencode-go");
+  assert.equal(instance.services.modelSelection.visionModel, "mimo-v2.5-free@opencode-go");
   assert.match(await readFile(envFile, "utf8"), /MODELDOCK_TRIAL=1/);
 
   const trialStatus = await (await fetch(`${instance.base}/api/status`)).json();
   assert.equal(trialStatus.config.trial, true);
-  assert.deepEqual(trialStatus.models.options.map((model) => model.id).sort(), ["deepseek-v4-flash-free", "mimo-v2.5-free"]);
+  assert.deepEqual(trialStatus.models.options.map((model) => model.id).sort(), ["deepseek-v4-flash-free@opencode-go", "mimo-v2.5-free@opencode-go"]);
 
   // /api/models cannot escape the trial pair while trial is active.
   const locked = await (await fetch(`${instance.base}/api/models`, {
@@ -269,7 +269,7 @@ test("config mode endpoint switches OFF / TRIAL / ON and locks the free pair in 
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ mainModel: "gpt-5.6-luna@opencode-go", visionModel: "kimi-k2.5" }),
   })).json();
-  assert.deepEqual(locked.selected, { mainModel: "deepseek-v4-flash-free", visionModel: "mimo-v2.5-free" });
+  assert.deepEqual(locked.selected, { mainModel: "deepseek-v4-flash-free@opencode-go", visionModel: "mimo-v2.5-free@opencode-go" });
 
   const on = await (await post({ mode: "on" })).json();
   assert.equal(on.enabled, true);

--- a/src/tts.mjs
+++ b/src/tts.mjs
@@ -59,9 +59,11 @@ export async function ttsSpeak({ text = "", voice = "zh-CN-XiaoxiaoNeural", outp
   const path = await import("node:path");
   const { MsEdgeTTS, OUTPUT_FORMAT } = await import("msedge-tts");
   const TTS = MsEdgeTTS || (await import("msedge-tts")).default;
-  const target = path.isAbsolute(output)
-    ? output
-    : path.join(tmpdir(), output);
+  // Confine the output to tmpdir: take only the basename so an absolute path or a
+  // "../../x" traversal from a (possibly prompt-injected) model cannot write the
+  // audio bytes to an arbitrary location (e.g. a startup script).
+  const safeName = path.basename(String(output)) || "tts-output.webm";
+  const target = path.join(tmpdir(), safeName);
   const tts = new TTS();
   await tts.setMetadata(voice, OUTPUT_FORMAT.WEBM_24KHZ_16BIT_MONO_OPUS);
   const { audioStream } = await tts.toStream(text);

--- a/src/tts.mjs
+++ b/src/tts.mjs
@@ -5,6 +5,9 @@
 // synthesized file path is returned to the model so it can be surfaced in the
 // conversation (same pattern as vision_inspect image refs).
 
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 const INSTALL_TIMEOUT_MS = 180_000;
 const SPEAK_TIMEOUT_MS = 120_000;
 
@@ -50,20 +53,23 @@ export async function ttsInstall() {
   return probeInstalled();
 }
 
+export function ttsOutputPath(output = "tts-output.webm") {
+  const requested = String(output || "tts-output.webm");
+  // The MCP contract explicitly supports an absolute destination. Relative
+  // values remain confined to tmpdir and lose any traversal components.
+  return path.isAbsolute(requested)
+    ? path.normalize(requested)
+    : path.join(tmpdir(), path.basename(requested) || "tts-output.webm");
+}
+
 export async function ttsSpeak({ text = "", voice = "zh-CN-XiaoxiaoNeural", output = "tts-output.webm" } = {}) {
   if (!text.trim()) throw new Error("speak requires a text payload");
   const ok = await probeInstalled();
   if (!ok) throw new Error("msedge-tts is not installed; install it first (dashboard Web tile or `npm install msedge-tts`)");
   const { writeFile } = await import("node:fs/promises");
-  const { tmpdir } = await import("node:os");
-  const path = await import("node:path");
   const { MsEdgeTTS, OUTPUT_FORMAT } = await import("msedge-tts");
   const TTS = MsEdgeTTS || (await import("msedge-tts")).default;
-  // Confine the output to tmpdir: take only the basename so an absolute path or a
-  // "../../x" traversal from a (possibly prompt-injected) model cannot write the
-  // audio bytes to an arbitrary location (e.g. a startup script).
-  const safeName = path.basename(String(output)) || "tts-output.webm";
-  const target = path.join(tmpdir(), safeName);
+  const target = ttsOutputPath(output);
   const tts = new TTS();
   await tts.setMetadata(voice, OUTPUT_FORMAT.WEBM_24KHZ_16BIT_MONO_OPUS);
   const { audioStream } = await tts.toStream(text);

--- a/src/tts.test.mjs
+++ b/src/tts.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ttsOutputPath } from "./tts.mjs";
+
+test("ttsOutputPath preserves the documented absolute destination", () => {
+  const output = path.resolve(tmpdir(), "modeldock-explicit", "speech.webm");
+  assert.equal(ttsOutputPath(output), path.normalize(output));
+});
+
+test("ttsOutputPath confines relative values to a temp filename", () => {
+  assert.equal(ttsOutputPath("../../speech.webm"), path.join(tmpdir(), "speech.webm"));
+  assert.equal(ttsOutputPath(""), path.join(tmpdir(), "tts-output.webm"));
+});

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -10,7 +10,7 @@
 
 import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -162,6 +162,15 @@ function stageFile(body, target) {
   // silently drop that mode bit.
   const mode = target.endsWith(".sh") ? 0o755 : 0o644;
   writeFileSync(tmp, body, { mode });
+  // Keep the previous bundle as .prev before replacing it: a checksum only proves
+  // the release was built that way, not that it boots on this machine/Node. If the
+  // new bundle fails to come up, the recover menu restores modeldock.mjs.prev so a
+  // bad update does not strand the user with a dead gateway and a switched config.
+  if (target.endsWith(`${path.sep}modeldock.mjs`) || target.endsWith("/modeldock.mjs")) {
+    if (existsSync(target)) {
+      try { copyFileSync(target, `${target}.prev`); } catch { /* best-effort */ }
+    }
+  }
   renameSync(tmp, target);
 }
 

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -10,7 +10,7 @@
 
 import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +22,10 @@ const SUMS_NAME = "SHA256SUMS";
 const CHECK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 const MAX_BUNDLE_BYTES = 64 * 1024 * 1024;
+// Rollback snapshots kept per install: one is the recovery material for the
+// current update, the second covers the previous update's recover menu while a
+// user works through it. Older full-layout copies would otherwise pile up.
+const MAX_ROLLBACK_SNAPSHOTS = 2;
 
 // Files an installed layout needs beyond the bundle itself. The release carries
 // every one of them as an asset (see release.yml), and an update deploys the
@@ -155,23 +159,131 @@ async function fetchSums(sumsUrl, fetchImpl = fetch) {
   return parseSumsFile((await fetchAsset(sumsUrl, 64 * 1024, fetchImpl)).toString("utf8"));
 }
 
-function stageFile(body, target) {
-  const tmp = `${target}.${process.pid}.tmp`;
+function removeFileIfPresent(file) {
+  try {
+    unlinkSync(file);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+function stagedPath(target) {
+  return `${target}.${process.pid}.update-stage`;
+}
+
+function backupPath(target) {
+  return `${target}.${process.pid}.update-backup`;
+}
+
+function writeStagedFile(body, target) {
+  const tmp = stagedPath(target);
   // Keep POSIX launchers executable after an update. The installer chmods these
   // files, but replacing a file with a newly-created temp file would otherwise
   // silently drop that mode bit.
   const mode = target.endsWith(".sh") ? 0o755 : 0o644;
+  removeFileIfPresent(tmp);
   writeFileSync(tmp, body, { mode });
-  // Keep the previous bundle as .prev before replacing it: a checksum only proves
-  // the release was built that way, not that it boots on this machine/Node. If the
-  // new bundle fails to come up, the recover menu restores modeldock.mjs.prev so a
-  // bad update does not strand the user with a dead gateway and a switched config.
-  if (target.endsWith(`${path.sep}modeldock.mjs`) || target.endsWith("/modeldock.mjs")) {
-    if (existsSync(target)) {
-      try { copyFileSync(target, `${target}.prev`); } catch { /* best-effort */ }
+  return tmp;
+}
+
+// Replace the platform layout as one recoverable set. Every new file and every
+// backup is prepared before the first destination changes. If any replacement
+// fails, all destinations already changed in this pass are restored before the
+// error reaches the API, so an update can never leave a new bundle beside old
+// launch/recovery scripts.
+function deployFilesAtomically(items, rootDir) {
+  const prepared = [];
+  let applied = 0;
+  let rollbackDir = "";
+  try {
+    for (const item of items) {
+      if (existsSync(item.dest) && !statSync(item.dest).isFile()) {
+        throw new Error(`Update destination is not a file: ${item.dest}`);
+      }
+      const stage = writeStagedFile(item.body, item.dest);
+      const backup = backupPath(item.dest);
+      const existed = existsSync(item.dest);
+      const preparedItem = { ...item, stage, backup, existed };
+      prepared.push(preparedItem);
+      removeFileIfPresent(backup);
+      if (existed) copyFileSync(item.dest, backup);
     }
+
+    for (const item of prepared) {
+      renameSync(item.stage, item.dest);
+      applied += 1;
+    }
+
+    // Preserve the entire previous platform layout, not just the bundle. A new
+    // bundle can depend on its matching bridge and lifecycle scripts, so runtime
+    // recovery must restore the same version set as one transaction.
+    const rollbackRoot = path.join(rootDir, ".modeldock-rollback");
+    const rollbackName = `${Date.now()}-${process.pid}`;
+    rollbackDir = path.join(rollbackRoot, rollbackName);
+    const files = [];
+    for (const item of prepared) {
+      const relative = path.relative(rootDir, item.dest).replaceAll(path.sep, "/");
+      if (!relative || relative.startsWith("../") || path.isAbsolute(relative)) {
+        throw new Error(`Update destination escaped the install root: ${item.dest}`);
+      }
+      files.push({ path: relative, existed: item.existed });
+      if (item.existed) {
+        const rollbackFile = path.join(rollbackDir, ...relative.split("/"));
+        mkdirSync(path.dirname(rollbackFile), { recursive: true });
+        copyFileSync(item.backup, rollbackFile);
+      }
+    }
+    mkdirSync(rollbackDir, { recursive: true });
+    writeFileSync(path.join(rollbackDir, "manifest.json"), `${JSON.stringify({ files }, null, 2)}\n`, "utf8");
+    const marker = path.join(rollbackRoot, "current");
+    const markerStage = `${marker}.${process.pid}.tmp`;
+    writeFileSync(markerStage, `${rollbackName}\n`, "utf8");
+    renameSync(markerStage, marker);
+
+    // Prune old snapshots now that the new marker is committed: the marker
+    // always points at the newest snapshot, so older ones are unreachable
+    // recovery material and safe to drop. Best-effort - a cleanup failure must
+    // not turn a committed deployment into an error.
+    try {
+      const snapshots = readdirSync(rollbackRoot)
+        .filter((name) => /^\d+-\d+$/.test(name))
+        .sort();
+      for (const old of snapshots.slice(0, Math.max(0, snapshots.length - MAX_ROLLBACK_SNAPSHOTS))) {
+        rmSync(path.join(rollbackRoot, old), { recursive: true, force: true });
+      }
+    } catch { /* stale snapshots are harmless */ }
+
+    // The deployment is committed once every destination and the complete
+    // rollback snapshot are in place. Backup cleanup is best-effort from here:
+    // treating a cleanup error
+    // as a deployment failure could start a rollback after earlier backups
+    // have already been deleted.
+    for (const item of prepared) {
+      try { removeFileIfPresent(item.backup); } catch { /* stale backup is safe */ }
+    }
+  } catch (error) {
+    const rollbackErrors = [];
+    for (let index = applied - 1; index >= 0; index -= 1) {
+      const item = prepared[index];
+      try {
+        if (item.existed) copyFileSync(item.backup, item.dest);
+        else removeFileIfPresent(item.dest);
+      } catch (rollbackError) {
+        rollbackErrors.push(`${item.dest}: ${rollbackError.message}`);
+      }
+    }
+    for (const item of prepared) {
+      try { removeFileIfPresent(item.stage); } catch { /* report the primary failure */ }
+      try { removeFileIfPresent(item.backup); } catch { /* report the primary failure */ }
+    }
+    if (rollbackDir) {
+      try { rmSync(rollbackDir, { recursive: true, force: true }); } catch { /* unreferenced partial snapshot */ }
+    }
+    if (rollbackErrors.length) {
+      throw new Error(`${error.message}; rollback failed: ${rollbackErrors.join("; ")}`);
+    }
+    throw error;
   }
-  renameSync(tmp, target);
 }
 
 // Relaunch after the current process exits: a detached shell waits for the port to
@@ -282,7 +394,7 @@ export function createUpdater({
           });
           staged.push({ body, dest: path.join(rootDir, ...target.dest) });
         }
-        for (const item of staged) stageFile(item.body, item.dest);
+        deployFilesAtomically(staged, rootDir);
       }
       restart();
       return { ok: true, mode, latestVersion: state.latestVersion, restarting: true };

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -23,14 +23,36 @@ const CHECK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 const MAX_BUNDLE_BYTES = 64 * 1024 * 1024;
 
+// Files an installed layout needs beyond the bundle itself. The release carries
+// every one of them as an asset (see release.yml), and an update deploys the
+// full set for the current platform so an install never mixes a new bundle
+// with old launcher/restart/recover scripts. Each entry is {asset, dest,
+// platforms}; dest is relative to the package root.
+const DEPLOY_TARGETS = {
+  "modeldock.mjs": { dest: ["dist", "modeldock.mjs"] },
+  "mcp-standalone.mjs": { dest: ["dist", "mcp-standalone.mjs"] },
+  "start-hidden.ps1": { dest: ["scripts", "start-hidden.ps1"], platforms: ["win32"] },
+  "restart.ps1": { dest: ["scripts", "restart.ps1"], platforms: ["win32"] },
+  "recover.ps1": { dest: ["scripts", "recover.ps1"], platforms: ["win32"] },
+  "start-hidden.sh": { dest: ["scripts", "start-hidden.sh"], platforms: ["linux", "darwin"] },
+  "restart.sh": { dest: ["scripts", "restart.sh"], platforms: ["linux", "darwin"] },
+  "recover.sh": { dest: ["scripts", "recover.sh"], platforms: ["linux", "darwin"] },
+};
+
+function deployTargetsFor(platform) {
+  return Object.entries(DEPLOY_TARGETS)
+    .filter(([, target]) => !target.platforms || target.platforms.includes(platform))
+    .map(([asset, target]) => ({ asset, ...target }));
+}
+
 // In the release bundle esbuild's `define` replaces this expression with the version
 // string literal; in a git checkout it is undefined and package.json is used.
 const BUILD_VERSION = process.env.MODELDOCK_BUILD_VERSION;
 
-export function localVersion() {
+export function localVersion(rootDir = root) {
   if (BUILD_VERSION) return BUILD_VERSION;
   try {
-    return JSON.parse(readFileSync(path.join(root, "package.json"), "utf8")).version || "0.0.0";
+    return JSON.parse(readFileSync(path.join(rootDir, "package.json"), "utf8")).version || "0.0.0";
   } catch {
     return "0.0.0";
   }
@@ -54,12 +76,15 @@ export function parseLatestRelease(release, current) {
   const assets = release?.assets || [];
   const asset = assets.find((a) => a?.name === ASSET_NAME);
   const sums = assets.find((a) => a?.name === SUMS_NAME);
+  const assetMap = {};
+  for (const item of assets) assetMap[item?.name] = item?.browser_download_url || "";
   return {
     available: compareVersions(tag, current) > 0,
     latestVersion: tag,
     assetUrl: asset?.browser_download_url || "",
     sumsUrl: sums?.browser_download_url || "",
     notesUrl: release?.html_url || "",
+    assets: assetMap,
   };
 }
 
@@ -85,24 +110,24 @@ function updateToken() {
   return process.env.MODELDOCK_GITHUB_TOKEN || process.env.GITHUB_TOKEN || "";
 }
 
-function isGitCheckout() {
-  return existsSync(path.join(root, ".git"));
+function isGitCheckout(rootDir) {
+  return existsSync(path.join(rootDir, ".git"));
 }
 
-function gitPull() {
+function gitPull(rootDir) {
   return new Promise((resolve, reject) => {
     // Explicit remote/branch so the update never depends on the checkout's
     // configured upstream (a detached or custom branch would otherwise fail
     // with "no tracking information").
-    execFile("git", ["pull", "--ff-only", "origin", "main"], { cwd: root, windowsHide: true }, (error, stdout, stderr) => {
+    execFile("git", ["pull", "--ff-only", "origin", "main"], { cwd: rootDir, windowsHide: true }, (error, stdout, stderr) => {
       if (error) reject(new Error(stderr?.trim() || error.message));
       else resolve(stdout);
     });
   });
 }
 
-async function fetchAsset(url, maxBytes) {
-  const response = await fetch(url, {
+async function fetchAsset(url, maxBytes, fetchImpl = fetch) {
+  const response = await fetchImpl(url, {
     redirect: "follow",
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
     headers: { "user-agent": "modeldock-updater" },
@@ -115,29 +140,36 @@ async function fetchAsset(url, maxBytes) {
   return body;
 }
 
-async function downloadBundle(assetUrl, sumsUrl) {
-  // Integrity: releases publish a SHA256SUMS asset (release.yml); refuse to install a
-  // bundle we cannot verify against it.
-  if (!sumsUrl) throw new Error("Release has no SHA256SUMS asset; refusing unverified update");
-  const sums = parseSumsFile((await fetchAsset(sumsUrl, 64 * 1024)).toString("utf8"));
-  const expected = sums[ASSET_NAME];
-  if (!expected) throw new Error(`SHA256SUMS has no entry for ${ASSET_NAME}`);
-  const body = await fetchAsset(assetUrl, MAX_BUNDLE_BYTES);
-  if (body.length < 100_000) throw new Error(`Downloaded bundle suspiciously small (${body.length} bytes)`);
+async function fetchVerified(assetUrl, expected, { minBytes = 0, fetchImpl = fetch } = {}) {
+  const body = await fetchAsset(assetUrl, MAX_BUNDLE_BYTES, fetchImpl);
+  if (body.length < minBytes) throw new Error(`Downloaded asset suspiciously small (${body.length} bytes)`);
   const actual = createHash("sha256").update(body).digest("hex");
-  if (actual !== expected) throw new Error(`Bundle checksum mismatch (expected ${expected.slice(0, 12)}..., got ${actual.slice(0, 12)}...)`);
-  const target = path.join(root, "dist", ASSET_NAME);
-  const tmp = `${target}.tmp`;
-  writeFileSync(tmp, body);
+  if (actual !== expected) {
+    throw new Error(`Checksum mismatch for ${assetUrl} (expected ${expected.slice(0, 12)}..., got ${actual.slice(0, 12)}...)`);
+  }
+  return body;
+}
+
+async function fetchSums(sumsUrl, fetchImpl = fetch) {
+  if (!sumsUrl) throw new Error("Release has no SHA256SUMS asset; refusing unverified update");
+  return parseSumsFile((await fetchAsset(sumsUrl, 64 * 1024, fetchImpl)).toString("utf8"));
+}
+
+function stageFile(body, target) {
+  const tmp = `${target}.${process.pid}.tmp`;
+  // Keep POSIX launchers executable after an update. The installer chmods these
+  // files, but replacing a file with a newly-created temp file would otherwise
+  // silently drop that mode bit.
+  const mode = target.endsWith(".sh") ? 0o755 : 0o644;
+  writeFileSync(tmp, body, { mode });
   renameSync(tmp, target);
-  return target;
 }
 
 // Relaunch after the current process exits: a detached shell waits for the port to
 // free up, then runs the hidden-start script. unref() so it survives our exit.
-function scheduleRestart() {
+function scheduleRestart(rootDir) {
   if (process.platform === "win32") {
-    const script = path.join(root, "scripts", "start-hidden.ps1");
+    const script = path.join(rootDir, "scripts", "start-hidden.ps1");
     // Single quotes in the path (e.g. a user name with an apostrophe) are escaped by
     // doubling, per PowerShell single-quoted string rules.
     const quoted = script.replace(/'/g, "''");
@@ -147,7 +179,7 @@ function scheduleRestart() {
       windowsHide: true,
     }).unref();
   } else {
-    const script = path.join(root, "scripts", "start-hidden.sh");
+    const script = path.join(rootDir, "scripts", "start-hidden.sh");
     const quoted = script.replace(/(["$`\\])/g, "\\$1");
     // "sh script" needs no executable bit; PATH gains this node's directory so the
     // launcher's bare "node" resolves even under launchd's minimal environment.
@@ -160,9 +192,16 @@ function scheduleRestart() {
   setTimeout(() => process.exit(0), 700).unref();
 }
 
-export function createUpdater({ fetchImpl = fetch } = {}) {
+export function createUpdater({
+  fetchImpl = fetch,
+  restartImpl,
+  autoCheckMs = 0,
+  rootDir = root,
+  platform = process.platform,
+} = {}) {
+  const restart = restartImpl || (() => scheduleRestart(rootDir));
   const state = {
-    currentVersion: localVersion(),
+    currentVersion: localVersion(rootDir),
     latestVersion: "",
     available: false,
     updating: false,
@@ -172,6 +211,7 @@ export function createUpdater({ fetchImpl = fetch } = {}) {
   };
   let assetUrl = "";
   let sumsUrl = "";
+  let releaseAssets = {};
 
   async function check() {
     try {
@@ -193,6 +233,7 @@ export function createUpdater({ fetchImpl = fetch } = {}) {
       state.error = "";
       assetUrl = parsed.assetUrl || "";
       sumsUrl = parsed.sumsUrl || "";
+      releaseAssets = parsed.assets || {};
     } catch (error) {
       state.error = error.message;
     }
@@ -206,16 +247,35 @@ export function createUpdater({ fetchImpl = fetch } = {}) {
     state.updating = true;
     try {
       let mode;
-      if (isGitCheckout()) {
+      if (isGitCheckout(rootDir)) {
         mode = "git";
-        await gitPull();
+        await gitPull(rootDir);
       } else {
         mode = "bundle";
-        if (!assetUrl) await check();
+        // Always re-check at click time: the button may have been rendered from a
+        // startup check while newer releases were published in the meantime, and
+        // apply() must deploy the newest release, not a cached one.
+        await check();
+        if (!state.available) throw new Error("No update available");
         if (!assetUrl) throw new Error("Release has no modeldock.mjs asset");
-        await downloadBundle(assetUrl, sumsUrl);
+        const sums = await fetchSums(sumsUrl, fetchImpl);
+        // Download and verify the whole set first; only then touch the installed
+        // files, so a failed download never leaves a half-updated layout.
+        const staged = [];
+        for (const target of deployTargetsFor(platform)) {
+          const url = releaseAssets[target.asset];
+          if (!url) throw new Error(`Release is missing ${target.asset}`);
+          const expected = sums[target.asset];
+          if (!expected) throw new Error(`SHA256SUMS has no entry for ${target.asset}`);
+          const body = await fetchVerified(url, expected, {
+            minBytes: target.asset === ASSET_NAME ? 100_000 : 0,
+            fetchImpl,
+          });
+          staged.push({ body, dest: path.join(rootDir, ...target.dest) });
+        }
+        for (const item of staged) stageFile(item.body, item.dest);
       }
-      scheduleRestart();
+      restart();
       return { ok: true, mode, latestVersion: state.latestVersion, restarting: true };
     } catch (error) {
       state.updating = false;
@@ -223,5 +283,14 @@ export function createUpdater({ fetchImpl = fetch } = {}) {
     }
   }
 
-  return { state: () => ({ ...state }), check, apply };
+  const api = { state: () => ({ ...state }), check, apply };
+  if (autoCheckMs > 0) {
+    // Keep the Update button current without a restart. unref() so the timer
+    // never keeps the process alive on its own.
+    const timer = setInterval(() => {
+      check().catch(() => {});
+    }, autoCheckMs);
+    timer.unref?.();
+  }
+  return api;
 }

--- a/src/update.test.mjs
+++ b/src/update.test.mjs
@@ -201,6 +201,11 @@ test("createUpdater.apply deploys the complete Windows install and rechecks at c
     oldFiles["scripts/start-hidden.sh"],
     "a non-current-platform helper must not be overwritten",
   );
+  assert.equal(
+    readFileSync(path.join(rootDir, "dist/modeldock.mjs.prev"), "utf8"),
+    oldFiles["dist/modeldock.mjs"],
+    "the previous bundle is kept as .prev so a bad update can be rolled back",
+  );
 });
 
 test("createUpdater.apply leaves an installed layout untouched when a helper is missing", async (t) => {

--- a/src/update.test.mjs
+++ b/src/update.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { compareVersions, parseLatestRelease, parseSumsFile, localVersion, createUpdater } from "./update.mjs";
@@ -201,11 +201,16 @@ test("createUpdater.apply deploys the complete Windows install and rechecks at c
     oldFiles["scripts/start-hidden.sh"],
     "a non-current-platform helper must not be overwritten",
   );
-  assert.equal(
-    readFileSync(path.join(rootDir, "dist/modeldock.mjs.prev"), "utf8"),
-    oldFiles["dist/modeldock.mjs"],
-    "the previous bundle is kept as .prev so a bad update can be rolled back",
+  const rollbackName = readFileSync(path.join(rootDir, ".modeldock-rollback/current"), "utf8").trim();
+  const rollbackDir = path.join(rootDir, ".modeldock-rollback", rollbackName);
+  const manifest = JSON.parse(readFileSync(path.join(rollbackDir, "manifest.json"), "utf8"));
+  assert.deepEqual(
+    manifest.files.map((file) => file.path),
+    ["dist/modeldock.mjs", "dist/mcp-standalone.mjs", "scripts/start-hidden.ps1", "scripts/restart.ps1", "scripts/recover.ps1"],
   );
+  for (const relative of manifest.files.map((file) => file.path)) {
+    assert.equal(readFileSync(path.join(rollbackDir, relative), "utf8"), oldFiles[relative], `${relative} should have a rollback copy`);
+  }
 });
 
 test("createUpdater.apply leaves an installed layout untouched when a helper is missing", async (t) => {
@@ -248,4 +253,141 @@ test("createUpdater.apply leaves an installed layout untouched when a helper is 
   for (const [relative, body] of Object.entries(original)) {
     assert.equal(readFileSync(path.join(rootDir, relative), "utf8"), body, `${relative} must remain unchanged`);
   }
+});
+
+test("createUpdater.apply rolls back the whole layout when a destination cannot be replaced", async (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-rollback-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "package.json"), JSON.stringify({ version: "0.2.5" }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, "scripts"));
+  const original = {
+    "dist/modeldock.mjs": "installed gateway",
+    "dist/mcp-standalone.mjs": "installed bridge",
+    "scripts/restart.ps1": "installed restart",
+    "scripts/recover.ps1": "installed recovery",
+  };
+  for (const [relative, body] of Object.entries(original)) writeFileSync(path.join(rootDir, relative), body);
+  // A corrupt layout with a directory at a helper destination used to fail only
+  // after the bundle and bridge had already been replaced.
+  mkdirSync(path.join(rootDir, "scripts/start-hidden.ps1"));
+  const assets = {
+    "modeldock.mjs": "new gateway".repeat(20_000),
+    "mcp-standalone.mjs": "new bridge",
+    "start-hidden.ps1": "new launcher",
+    "restart.ps1": "new restart",
+    "recover.ps1": "new recovery",
+  };
+  const sums = Object.entries(assets).map(([name, body]) => `${sha256(body)}  ${name}`).join("\n");
+  const fetchImpl = async (url) => {
+    if (url.includes("api.github.com")) return releaseResponse("0.2.6", assets, sums);
+    if (url.endsWith("/SHA256SUMS")) return responseBody(sums);
+    return responseBody(assets[url.split("/").pop()]);
+  };
+  const updater = createUpdater({
+    fetchImpl,
+    restartImpl: () => assert.fail("restart must not happen after a failed deployment"),
+    rootDir,
+    platform: "win32",
+  });
+
+  await updater.check();
+  await assert.rejects(() => updater.apply(), /destination is not a file/);
+  for (const [relative, body] of Object.entries(original)) {
+    assert.equal(readFileSync(path.join(rootDir, relative), "utf8"), body, `${relative} must be rolled back`);
+  }
+});
+
+test("createUpdater.apply rolls back when the complete rollback snapshot cannot be written", async (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-prev-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "package.json"), JSON.stringify({ version: "0.2.5" }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, "scripts"));
+  const original = {
+    "dist/modeldock.mjs": "installed gateway",
+    "dist/mcp-standalone.mjs": "installed bridge",
+    "scripts/start-hidden.ps1": "installed launcher",
+    "scripts/restart.ps1": "installed restart",
+    "scripts/recover.ps1": "installed recovery",
+  };
+  for (const [relative, body] of Object.entries(original)) writeFileSync(path.join(rootDir, relative), body);
+  writeFileSync(path.join(rootDir, ".modeldock-rollback"), "blocked rollback directory");
+  const assets = {
+    "modeldock.mjs": "new gateway".repeat(20_000),
+    "mcp-standalone.mjs": "new bridge",
+    "start-hidden.ps1": "new launcher",
+    "restart.ps1": "new restart",
+    "recover.ps1": "new recovery",
+  };
+  const sums = Object.entries(assets).map(([name, body]) => `${sha256(body)}  ${name}`).join("\n");
+  const fetchImpl = async (url) => {
+    if (url.includes("api.github.com")) return releaseResponse("0.2.6", assets, sums);
+    if (url.endsWith("/SHA256SUMS")) return responseBody(sums);
+    return responseBody(assets[url.split("/").pop()]);
+  };
+  const updater = createUpdater({ fetchImpl, restartImpl: () => {}, rootDir, platform: "win32" });
+
+  await updater.check();
+  await assert.rejects(() => updater.apply());
+  for (const [relative, body] of Object.entries(original)) {
+    assert.equal(readFileSync(path.join(rootDir, relative), "utf8"), body, `${relative} must remain unchanged`);
+  }
+});
+
+test("createUpdater.apply keeps only the two most recent rollback snapshots", async (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-prune-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "package.json"), JSON.stringify({ version: "0.2.5" }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, "scripts"));
+  for (const [relative, body] of Object.entries({
+    "dist/modeldock.mjs": "installed gateway",
+    "dist/mcp-standalone.mjs": "installed bridge",
+    "scripts/start-hidden.ps1": "installed launcher",
+    "scripts/restart.ps1": "installed restart",
+    "scripts/recover.ps1": "installed recovery",
+  })) writeFileSync(path.join(rootDir, relative), body);
+
+  const assets = {
+    "modeldock.mjs": "new gateway".repeat(20_000),
+    "mcp-standalone.mjs": "new bridge",
+    "start-hidden.ps1": "new launcher",
+    "restart.ps1": "new restart",
+    "recover.ps1": "new recovery",
+  };
+  const sums = Object.entries(assets).map(([name, body]) => `${sha256(body)}  ${name}`).join("\n");
+  let releaseChecks = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes("api.github.com")) {
+      releaseChecks += 1;
+      return releaseResponse(releaseChecks === 1 ? "0.2.6" : "0.2.7", assets, sums);
+    }
+    if (url.endsWith("/SHA256SUMS")) return responseBody(sums);
+    return responseBody(assets[url.split("/").pop()]);
+  };
+  // apply() leaves the updater in "updating" state by design (the process
+  // restarts right after a real update), so the second deployment uses a fresh
+  // instance that shares the release feed.
+  const updater = createUpdater({ fetchImpl, restartImpl: () => {}, rootDir, platform: "win32" });
+  await updater.check();
+  await updater.apply();
+  const rollbackRoot = path.join(rootDir, ".modeldock-rollback");
+  const firstCurrent = readFileSync(path.join(rollbackRoot, "current"), "utf8").trim();
+  // Plant one stale snapshot, then run a second update: the newest snapshot
+  // plus the previous real generation must survive, while the stale one is pruned.
+  const staleSnapshot = "0000000000000-111";
+  const staleDir = path.join(rollbackRoot, staleSnapshot);
+  mkdirSync(staleDir, { recursive: true });
+  writeFileSync(path.join(staleDir, "manifest.json"), '{"files":[]}\n');
+  const updater2 = createUpdater({ fetchImpl, restartImpl: () => {}, rootDir, platform: "win32" });
+  await updater2.check();
+  await updater2.apply();
+
+  const snapshots = readdirSync(rollbackRoot).filter((name) => /^\d+-\d+$/.test(name)).sort();
+  assert.equal(snapshots.length, 2, "only the two most recent snapshots are kept");
+  assert.ok(!snapshots.includes(staleSnapshot), "the stale snapshot is pruned");
+  assert.ok(snapshots.includes(firstCurrent), "the previous generation survives");
+  const current = readFileSync(path.join(rollbackRoot, "current"), "utf8").trim();
+  assert.equal(current, snapshots[1], "the marker still points at the newest snapshot");
 });

--- a/src/update.test.mjs
+++ b/src/update.test.mjs
@@ -1,6 +1,41 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { compareVersions, parseLatestRelease, parseSumsFile, localVersion, createUpdater } from "./update.mjs";
+
+function responseBody(body) {
+  const bytes = Buffer.from(body);
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => String(bytes.length) },
+    arrayBuffer: async () => bytes,
+  };
+}
+
+function releaseResponse(tag, assets, sums = "") {
+  const releaseAssets = { ...assets, ...(sums ? { SHA256SUMS: sums } : {}) };
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      tag_name: `v${tag}`,
+      html_url: `https://example.com/releases/v${tag}`,
+      assets: Object.entries(releaseAssets).map(([name, body]) => ({
+        name,
+        browser_download_url: `https://assets.example/${tag}/${name}`,
+        body,
+      })),
+    }),
+  };
+}
+
+function sha256(body) {
+  return createHash("sha256").update(body).digest("hex");
+}
 
 test("compareVersions orders dotted versions numerically", () => {
   assert.ok(compareVersions("0.2.0", "0.1.0") > 0);
@@ -96,4 +131,116 @@ test("createUpdater.check records errors without throwing", async () => {
 test("createUpdater.apply refuses when no update is available", async () => {
   const updater = createUpdater({ fetchImpl: async () => ({ ok: false, status: 404 }) });
   await assert.rejects(() => updater.apply(), /No update available/);
+});
+
+test("createUpdater.apply deploys the complete Windows install and rechecks at click time", async (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "package.json"), JSON.stringify({ version: "0.2.5" }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, "scripts"));
+
+  const oldFiles = {
+    "dist/modeldock.mjs": "old gateway",
+    "dist/mcp-standalone.mjs": "old bridge",
+    "scripts/start-hidden.ps1": "old launcher",
+    "scripts/restart.ps1": "old restart",
+    "scripts/recover.ps1": "old recovery",
+    "scripts/start-hidden.sh": "posix file must not change on Windows",
+  };
+  for (const [relative, body] of Object.entries(oldFiles)) {
+    writeFileSync(path.join(rootDir, relative), body);
+  }
+
+  const assets = {
+    "modeldock.mjs": "new gateway".repeat(20_000),
+    "mcp-standalone.mjs": "new bridge",
+    "start-hidden.ps1": "new launcher",
+    "restart.ps1": "new restart",
+    "recover.ps1": "new recovery",
+    "start-hidden.sh": "new posix launcher",
+  };
+  const sums = Object.entries(assets)
+    .map(([name, body]) => `${sha256(body)}  ${name}`)
+    .join("\n");
+  let releaseChecks = 0;
+  const fetchImpl = async (url) => {
+    if (url.includes("api.github.com")) {
+      releaseChecks += 1;
+      return releaseResponse(releaseChecks === 1 ? "0.2.6" : "0.2.7", assets, sums);
+    }
+    if (url.endsWith("/SHA256SUMS")) return responseBody(sums);
+    const name = url.split("/").pop();
+    return responseBody(assets[name]);
+  };
+  let restartCalls = 0;
+  const updater = createUpdater({
+    fetchImpl,
+    restartImpl: () => { restartCalls += 1; },
+    rootDir,
+    platform: "win32",
+  });
+
+  assert.equal((await updater.check()).latestVersion, "0.2.6");
+  const result = await updater.apply();
+
+  assert.equal(result.latestVersion, "0.2.7");
+  assert.equal(releaseChecks, 2, "apply should re-check instead of trusting stale startup state");
+  assert.equal(restartCalls, 1);
+  for (const [relative, body] of Object.entries({
+    "dist/modeldock.mjs": assets["modeldock.mjs"],
+    "dist/mcp-standalone.mjs": assets["mcp-standalone.mjs"],
+    "scripts/start-hidden.ps1": assets["start-hidden.ps1"],
+    "scripts/restart.ps1": assets["restart.ps1"],
+    "scripts/recover.ps1": assets["recover.ps1"],
+  })) {
+    assert.equal(readFileSync(path.join(rootDir, relative), "utf8"), body, `${relative} should be updated`);
+  }
+  assert.equal(
+    readFileSync(path.join(rootDir, "scripts/start-hidden.sh"), "utf8"),
+    oldFiles["scripts/start-hidden.sh"],
+    "a non-current-platform helper must not be overwritten",
+  );
+});
+
+test("createUpdater.apply leaves an installed layout untouched when a helper is missing", async (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-missing-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  writeFileSync(path.join(rootDir, "package.json"), JSON.stringify({ version: "0.2.5" }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, "scripts"));
+  const original = {
+    "dist/modeldock.mjs": "installed gateway",
+    "dist/mcp-standalone.mjs": "installed bridge",
+    "scripts/start-hidden.ps1": "installed launcher",
+    "scripts/restart.ps1": "installed restart",
+    "scripts/recover.ps1": "installed recovery",
+  };
+  for (const [relative, body] of Object.entries(original)) writeFileSync(path.join(rootDir, relative), body);
+  const assets = {
+    "modeldock.mjs": "new gateway".repeat(20_000),
+    "mcp-standalone.mjs": "new bridge",
+    "start-hidden.ps1": "new launcher",
+    "restart.ps1": "new restart",
+  };
+  const sums = Object.entries(assets)
+    .map(([name, body]) => `${sha256(body)}  ${name}`)
+    .join("\n");
+  const fetchImpl = async (url) => {
+    if (url.includes("api.github.com")) return releaseResponse("0.2.6", assets, sums);
+    if (url.endsWith("/SHA256SUMS")) return responseBody(sums);
+    return responseBody(assets[url.split("/").pop()]);
+  };
+  const updater = createUpdater({
+    fetchImpl,
+    restartImpl: () => assert.fail("restart must not happen after an incomplete release"),
+    rootDir,
+    platform: "win32",
+  });
+
+  await updater.check();
+  await assert.rejects(() => updater.apply(), /Release is missing recover\.ps1/);
+  for (const [relative, body] of Object.entries(original)) {
+    assert.equal(readFileSync(path.join(rootDir, relative), "utf8"), body, `${relative} must remain unchanged`);
+  }
 });

--- a/src/upstreams.mjs
+++ b/src/upstreams.mjs
@@ -194,7 +194,12 @@ export function createUpstreams({ config, metrics, mediaStore, memoryStore = nul
       const stat = statSync(absolute);
       if (!stat.isFile()) throw new Error(`Image path is not a file: ${absolute}`);
       const ext = extname(absolute).toLowerCase();
-      const mime = ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : ext === ".png" ? "image/png" : ext === ".gif" ? "image/gif" : ext === ".webp" ? "image/webp" : ext === ".bmp" ? "image/bmp" : "image/png";
+      // Only read recognized image types. Falling back to image/png for anything
+      // let a (possibly prompt-injected) model exfiltrate arbitrary local files
+      // (keys, /etc/shadow, .env) to the upstream vision model as "an image".
+      const mimeByExt = { ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".gif": "image/gif", ".webp": "image/webp", ".bmp": "image/bmp" };
+      const mime = mimeByExt[ext];
+      if (!mime) throw new Error(`Unsupported image type: ${absolute} (allowed: jpg, jpeg, png, gif, webp, bmp)`);
       const bytes = readFileSync(absolute);
       if (bytes.byteLength > mediaStore.maxBytes) throw new Error(`Image exceeds the ${mediaStore.maxBytes}-byte limit: ${absolute}`);
       return `data:${mime};base64,${bytes.toString("base64")}`;

--- a/test/install-macos-sim.test.mjs
+++ b/test/install-macos-sim.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { readFileSync, existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { createServer } from "node:http";
 import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const isWindows = process.platform === "win32";
@@ -55,13 +56,14 @@ function writeFakeMacTools(binDir) {
 
 // Env shared by the install.sh sandbox. `fakeBin` must already exist and be
 // executable on the POSIX side before install.sh runs.
-function sandboxEnv({ root, fakeBin, launchctlLog, releaseUrl, bridgeUrl, skillBaseUrl, port }) {
+function sandboxEnv({ root, fakeBin, launchctlLog, releaseUrl, bridgeUrl, sumsUrl, skillBaseUrl, port }) {
   return {
     MODELDOCK_ROOT: root,
     MODELDOCK_STATE_DIR: `${root}/.modeldock`,
     MODELDOCK_AUTOSTART_PLIST_DIR: `${root}/LaunchAgents`,
     MODELDOCK_RELEASE_URL: releaseUrl,
     MODELDOCK_BRIDGE_URL: bridgeUrl,
+    MODELDOCK_SUMS_URL: sumsUrl,
     MODELDOCK_SKILL_BASE_URL: skillBaseUrl,
     MODELDOCK_CODEX_HOME: `${root}/codex-home`,
     MODELDOCK_SKIP_OPEN: "1",
@@ -85,6 +87,12 @@ test("install.sh macOS branch: plist, launchctl, marker (WSL or direct)", async 
     let data = null;
     if (req.url === "/modeldock.mjs") data = bundle;
     else if (req.url === "/mcp-standalone.mjs") data = bridge;
+    else if (req.url === "/SHA256SUMS") {
+      data = Buffer.from(
+        `${createHash("sha256").update(bundle).digest("hex")}  modeldock.mjs\n` +
+          `${createHash("sha256").update(bridge).digest("hex")}  mcp-standalone.mjs\n`,
+      );
+    }
     else if (req.url.startsWith("/skills/content-to-video/")) {
       const rel = req.url.slice("/skills/content-to-video/".length).split("/");
       const file = path.join(skillRoot, ...rel);
@@ -109,6 +117,7 @@ test("install.sh macOS branch: plist, launchctl, marker (WSL or direct)", async 
   const installer = path.join(repoRoot, "scripts", "install.sh");
   const releaseUrl = `http://127.0.0.1:${assetPort}/modeldock.mjs`;
   const bridgeUrl = `http://127.0.0.1:${assetPort}/mcp-standalone.mjs`;
+  const sumsUrl = `http://127.0.0.1:${assetPort}/SHA256SUMS`;
   const skillBaseUrl = `http://127.0.0.1:${assetPort}/skills/content-to-video`;
   const probe = createServer();
   const appPort = await listen(probe);
@@ -119,7 +128,7 @@ test("install.sh macOS branch: plist, launchctl, marker (WSL or direct)", async 
   let err = "";
   const env = isWindows
     ? undefined
-    : { ...process.env, ...sandboxEnv({ root: installDir, fakeBin, launchctlLog, releaseUrl, bridgeUrl, skillBaseUrl, port: appPort }) };
+    : { ...process.env, ...sandboxEnv({ root: installDir, fakeBin, launchctlLog, releaseUrl, bridgeUrl, sumsUrl, skillBaseUrl, port: appPort }) };
   if (isWindows) {
     // Drive install.sh from inside WSL: the sandbox dir is on the Windows side,
     // and the fake node/uname/launchctl shims live there too. The runner script
@@ -135,6 +144,7 @@ test("install.sh macOS branch: plist, launchctl, marker (WSL or direct)", async 
       launchctlLog: wslLaunchctlLog,
       releaseUrl,
       bridgeUrl,
+      sumsUrl,
       skillBaseUrl,
       port: appPort,
     });

--- a/test/install-mock.test.mjs
+++ b/test/install-mock.test.mjs
@@ -554,6 +554,12 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
         "content-length": bridgeAsset.length,
       });
       res.end(bridgeAsset);
+    } else if (req.url === "/SHA256SUMS") {
+      const text =
+        `${createHash("sha256").update(asset).digest("hex")}  modeldock.mjs\n` +
+        `${createHash("sha256").update(bridgeAsset).digest("hex")}  mcp-standalone.mjs\n`;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(text);
     } else if (req.url.startsWith("/skills/content-to-video/")) {
       const rel = req.url.slice("/skills/content-to-video/".length).split("/");
       const file = path.join(skillRoot, ...rel);
@@ -615,6 +621,7 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
     MODELDOCK_ROOT: installDir,
     MODELDOCK_RELEASE_URL: releaseUrl,
     MODELDOCK_BRIDGE_URL: `http://127.0.0.1:${assetPort}/mcp-standalone.mjs`,
+    MODELDOCK_SUMS_URL: `http://127.0.0.1:${assetPort}/SHA256SUMS`,
     MODELDOCK_SKILL_BASE_URL: skillBaseUrl,
     MODELDOCK_CODEX_HOME: codexHome,
     MODELDOCK_PORT: String(appPort),
@@ -893,6 +900,12 @@ test("mock install: auto-download a bundled Node 22 LTS when none is suitable", 
     } else if (url === "/mcp-standalone.mjs") {
       res.writeHead(200, { "content-type": "application/octet-stream", "content-length": fakeBridge.length });
       res.end(fakeBridge);
+    } else if (url === "/SHA256SUMS") {
+      const text =
+        `${createHash("sha256").update(bundle).digest("hex")}  modeldock.mjs\n` +
+        `${createHash("sha256").update(fakeBridge).digest("hex")}  mcp-standalone.mjs\n`;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(text);
     } else if (url === "/index.json") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(indexJson);
@@ -933,6 +946,7 @@ test("mock install: auto-download a bundled Node 22 LTS when none is suitable", 
     MODELDOCK_ROOT: installDir,
     MODELDOCK_RELEASE_URL: `http://127.0.0.1:${serverPort}/modeldock.mjs`,
     MODELDOCK_BRIDGE_URL: `http://127.0.0.1:${serverPort}/mcp-standalone.mjs`,
+    MODELDOCK_SUMS_URL: `http://127.0.0.1:${serverPort}/SHA256SUMS`,
     MODELDOCK_NODE_BASE_URL: `http://127.0.0.1:${serverPort}`,
     MODELDOCK_FORCE_NODE_DOWNLOAD: "1",
     // The Windows fixture node.exe is a text file; executing it would make Windows
@@ -1028,6 +1042,13 @@ test("mock install: rejects a Node download whose SHA256 does not match", async 
     } else if (url === "/mcp-standalone.mjs") {
       res.writeHead(200, { "content-type": "application/octet-stream", "content-length": fakeBridge.length });
       res.end(fakeBridge);
+    } else if (url === "/SHA256SUMS") {
+      const bundle = readFileSync(path.join(repoRoot, "dist", "modeldock.mjs"));
+      const text =
+        `${createHash("sha256").update(bundle).digest("hex")}  modeldock.mjs\n` +
+        `${createHash("sha256").update(fakeBridge).digest("hex")}  mcp-standalone.mjs\n`;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(text);
     } else if (url === "/index.json") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(indexJson);
@@ -1062,6 +1083,7 @@ test("mock install: rejects a Node download whose SHA256 does not match", async 
     MODELDOCK_ROOT: installDir,
     MODELDOCK_RELEASE_URL: `http://127.0.0.1:${serverPort}/modeldock.mjs`,
     MODELDOCK_BRIDGE_URL: `http://127.0.0.1:${serverPort}/mcp-standalone.mjs`,
+    MODELDOCK_SUMS_URL: `http://127.0.0.1:${serverPort}/SHA256SUMS`,
     MODELDOCK_NODE_BASE_URL: `http://127.0.0.1:${serverPort}`,
     MODELDOCK_FORCE_NODE_DOWNLOAD: "1",
     MODELDOCK_PORT: String(appPort),

--- a/test/recover-autostart.test.mjs
+++ b/test/recover-autostart.test.mjs
@@ -23,6 +23,27 @@ test("recover.sh ships a start-at-login repair in both copies", () => {
   }
 });
 
+test("recovery restores a complete version snapshot through the canonical restart", () => {
+  const posix = readFileSync(new URL("../scripts/recover.sh", import.meta.url), "utf8");
+  const windows = readFileSync(new URL("../scripts/recover.ps1", import.meta.url), "utf8");
+  assert.match(posix, /\.modeldock-rollback\/current/);
+  assert.match(posix, /manifest\.json/);
+  assert.match(posix, /scripts\/restart\.sh/);
+  assert.doesNotMatch(posix, /modeldock\.mjs\.prev/);
+  assert.match(windows, /\.modeldock-rollback/);
+  assert.match(windows, /manifest\.json/);
+  assert.match(windows, /restored the complete previous version set/);
+  assert.doesNotMatch(windows, /modeldock\.mjs\.prev/);
+});
+
+test("restart.sh cascades listener discovery and refuses an unidentified healthy port", () => {
+  const restart = readFileSync(new URL("../scripts/restart.sh", import.meta.url), "utf8");
+  assert.match(restart, /if command -v lsof[\s\S]*if command -v ss[\s\S]*if command -v fuser/);
+  assert.doesNotMatch(restart, /elif command -v ss/);
+  assert.match(restart, /refusing a fake restart/);
+  assert.match(restart, /kill "\$NEW_PID"/);
+});
+
 test("install.sh warns loudly when the login agent cannot be loaded", () => {
   const install = readFileSync(new URL("../scripts/install.sh", import.meta.url), "utf8");
   assert.match(install, /ERROR: could not enable start at login/, "load failure must not be silent");

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -24,7 +24,7 @@ test("publishes a complete Codex model catalog schema", () => {
     // the provider-grouped order would put a native GPT model first.
     nativeCatalogFile: path.join(os.tmpdir(), "modeldock-test-native-missing.json"),
   });
-  assert.equal(catalog.models[0].slug, "deepseek-v4-flash");
+  assert.equal(catalog.models[0].slug, "deepseek-v4-flash@opencode-go");
   assert.equal(catalog.models[0].supports_reasoning_summaries, true);
   assert.match(catalog.models[0].base_instructions, /coding agent/);
   assert.equal(catalog.models[0].model_messages.instructions_variables.personality_pragmatic, "");


### PR DESCRIPTION
## Summary
- deploy the complete platform-specific installed layout on in-app updates
- publish and verify all helper scripts in release assets and SHA256SUMS
- verify installer downloads and add updater/install regression coverage
- bump version to 0.2.6

## Verification
- npm run build
- npm test (331 passed, 1 skipped)
- npm run test:install (6 passed)