### PR TITLE
Harden lifecycle recovery and MCP access

### DIFF
--- a/config/codex.example.toml
+++ b/config/codex.example.toml
@@ -20,9 +20,10 @@ args = ["C:\\Users\\you\\modeldock\\src\\mcp-standalone.mjs"]
 env = { "MODELDOCK_GATEWAY_URL" = "http://127.0.0.1:4097" }
 
 # With MODELDOCK_MCP_TRANSPORT=url in .env, the managed block points at the
-# gateway's streamable-HTTP /mcp endpoint instead:
+# gateway's caller-key-protected streamable-HTTP MCP endpoint instead. The
+# dashboard writes the real key; do not copy this placeholder literally:
 # [mcp_servers.modeldock]
-# url = "http://127.0.0.1:4097/mcp"
+# url = "http://127.0.0.1:4097/c/<caller-key>/mcp"
 
 # The legacy `model_provider = "modeldock_go"` shape (a custom provider with an
 # experimental_bearer_token) is migrated in place when ModelDock re-enables the

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -288,21 +288,34 @@ if ($listener) {
   # MODELDOCK_STATE_DIR redirect, or the guard reads a file the gateway never wrote.
   $stateDir = if ($env:MODELDOCK_STATE_DIR) { $env:MODELDOCK_STATE_DIR } else { Join-Path $env:USERPROFILE ".modeldock" }
   $ownerFile = Join-Path $stateDir "owner-$port.json"
-  if ((Test-Path $ownerFile) -and (-not $args.Contains("-Force"))) {
+  $forceTakeover = $args -contains "-Force"
+  if (-not $forceTakeover) {
+    $owned = $false
     try {
+      if (-not (Test-Path -LiteralPath $ownerFile)) { throw "owner record is missing" }
       $owner = Get-Content $ownerFile -Raw | ConvertFrom-Json
-      if ($owner.root -and $owner.pid -eq $oldPid) {
-        $ownerRoot = [System.IO.Path]::GetFullPath($owner.root)
-        $thisRoot = [System.IO.Path]::GetFullPath($root)
-        if ($ownerRoot -ne $thisRoot) {
-          Write-Status "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
-          Write-Status "Re-run with -Force to take the port over deliberately."
-          exit 1
-        }
+      $ownerRoot = [System.IO.Path]::GetFullPath([string]$owner.root)
+      $thisRoot = [System.IO.Path]::GetFullPath($root)
+      if ([int]$owner.pid -ne [int]$oldPid -or [int]$owner.port -ne $port -or $ownerRoot -ne $thisRoot) {
+        throw "owner record does not match this listener and install root"
       }
+      $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $oldPid" -ErrorAction Stop
+      $commandLine = [string]$processInfo.CommandLine
+      $sourceEntry = [System.IO.Path]::GetFullPath((Join-Path $root "src\server.mjs"))
+      $bundleEntry = [System.IO.Path]::GetFullPath((Join-Path $root "dist\modeldock.mjs"))
+      $owned = $commandLine.IndexOf($sourceEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+          $commandLine.IndexOf($bundleEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+      if (-not $owned) { throw "listener command does not run this ModelDock install" }
     } catch {
-      # Unreadable owner file: fall through and behave as before.
+      Write-Status "ERROR: refusing to stop PID $oldPid on port $port because ownership could not be verified: $($_.Exception.Message)"
+      Write-Status "Re-run with -Force to take the port over deliberately."
+      exit 2
     }
+  }
+  $currentListener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($currentListener -and $currentListener.OwningProcess -ne $oldPid -and (-not $forceTakeover)) {
+    Write-Status "ERROR: the listener on port $port changed during ownership verification; refusing to stop it."
+    exit 2
   }
   Write-Status "restart.ps1: stopping gateway (PID $oldPid, port $port)"
   Stop-Process -Id $oldPid -Force

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -300,21 +300,34 @@ if ($listener) {
   # MODELDOCK_STATE_DIR redirect, or the guard reads a file the gateway never wrote.
   $stateDir = if ($env:MODELDOCK_STATE_DIR) { $env:MODELDOCK_STATE_DIR } else { Join-Path $env:USERPROFILE ".modeldock" }
   $ownerFile = Join-Path $stateDir "owner-$port.json"
-  if ((Test-Path $ownerFile) -and (-not $args.Contains("-Force"))) {
+  $forceTakeover = $args -contains "-Force"
+  if (-not $forceTakeover) {
+    $owned = $false
     try {
+      if (-not (Test-Path -LiteralPath $ownerFile)) { throw "owner record is missing" }
       $owner = Get-Content $ownerFile -Raw | ConvertFrom-Json
-      if ($owner.root -and $owner.pid -eq $oldPid) {
-        $ownerRoot = [System.IO.Path]::GetFullPath($owner.root)
-        $thisRoot = [System.IO.Path]::GetFullPath($root)
-        if ($ownerRoot -ne $thisRoot) {
-          Write-Status "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
-          Write-Status "Re-run with -Force to take the port over deliberately."
-          exit 1
-        }
+      $ownerRoot = [System.IO.Path]::GetFullPath([string]$owner.root)
+      $thisRoot = [System.IO.Path]::GetFullPath($root)
+      if ([int]$owner.pid -ne [int]$oldPid -or [int]$owner.port -ne $port -or $ownerRoot -ne $thisRoot) {
+        throw "owner record does not match this listener and install root"
       }
+      $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $oldPid" -ErrorAction Stop
+      $commandLine = [string]$processInfo.CommandLine
+      $sourceEntry = [System.IO.Path]::GetFullPath((Join-Path $root "src\server.mjs"))
+      $bundleEntry = [System.IO.Path]::GetFullPath((Join-Path $root "dist\modeldock.mjs"))
+      $owned = $commandLine.IndexOf($sourceEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+          $commandLine.IndexOf($bundleEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+      if (-not $owned) { throw "listener command does not run this ModelDock install" }
     } catch {
-      # Unreadable owner file: fall through and behave as before.
+      Write-Status "ERROR: refusing to stop PID $oldPid on port $port because ownership could not be verified: $($_.Exception.Message)"
+      Write-Status "Re-run with -Force to take the port over deliberately."
+      exit 2
     }
+  }
+  $currentListener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($currentListener -and $currentListener.OwningProcess -ne $oldPid -and (-not $forceTakeover)) {
+    Write-Status "ERROR: the listener on port $port changed during ownership verification; refusing to stop it."
+    exit 2
   }
   Write-Status "restart.ps1: stopping gateway (PID $oldPid, port $port)"
   Stop-Process -Id $oldPid -Force
@@ -544,29 +557,33 @@ check_owner() {
   [ "$FORCE" -eq 0 ] || return 0
   state_dir="${MODELDOCK_STATE_DIR:-$HOME/.modeldock}"
   owner_file="$state_dir/owner-$PORT.json"
-  [ -f "$owner_file" ] || return 0
-  "$NODE_BIN" --input-type=module - "$owner_file" "$OLD_PID" "$ROOT" <<'NODE'
+  "$NODE_BIN" --input-type=module - "$owner_file" "$OLD_PID" "$ROOT" "$PORT" <<'NODE'
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-const [ownerFile, oldPid, root] = process.argv.slice(2);
+const [ownerFile, oldPid, root, port] = process.argv.slice(2);
 try {
   const owner = JSON.parse(fs.readFileSync(ownerFile, "utf8"));
-  if (owner?.root && Number(owner.pid) === Number(oldPid)) {
-    const ownerRoot = path.resolve(owner.root);
-    const thisRoot = path.resolve(root);
-    if (ownerRoot !== thisRoot) {
-      const first = `ERROR: port ${owner.port || ""} is owned by a gateway from '${ownerRoot}' (PID ${oldPid}); this script runs from '${thisRoot}'.`;
-      const second = "Re-run with --force to take the port over deliberately.";
-      console.log(first);
-      console.log(second);
-      console.error(first);
-      console.error(second);
-      process.exit(2);
-    }
+  const ownerRoot = path.resolve(String(owner?.root || ""));
+  const thisRoot = path.resolve(root);
+  if (Number(owner?.pid) !== Number(oldPid) || Number(owner?.port) !== Number(port) || ownerRoot !== thisRoot) {
+    throw new Error("owner record does not match this listener and install root");
   }
-} catch {
-  // Unreadable owner file: match restart.ps1 and behave as before.
+  const candidates = [path.join(thisRoot, "src", "server.mjs"), path.join(thisRoot, "dist", "modeldock.mjs")];
+  let commandMatches = false;
+  if (process.platform === "linux") {
+    const argv = fs.readFileSync(`/proc/${oldPid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+    commandMatches = argv.some((arg) => candidates.includes(path.resolve(arg)));
+  } else {
+    const command = execFileSync("ps", ["-p", oldPid, "-o", "command="], { encoding: "utf8" });
+    commandMatches = candidates.some((candidate) => command.includes(candidate));
+  }
+  if (!commandMatches) throw new Error("listener command does not run this ModelDock install");
+} catch (error) {
+  console.error(`ERROR: refusing to stop PID ${oldPid} on port ${port} because ownership could not be verified: ${error.message}`);
+  console.error("Re-run with --force to take the port over deliberately.");
+  process.exit(2);
 }
 NODE
 }
@@ -611,6 +628,11 @@ if try_launchd_restart; then
 fi
 
 if [ -n "$OLD_PID" ]; then
+  current_pid="$(find_listener_pid)"
+  if [ "$FORCE" -eq 0 ] && [ -n "$current_pid" ] && [ "$current_pid" != "$OLD_PID" ]; then
+    status "ERROR: the listener on port $PORT changed during ownership verification; refusing to stop it"
+    exit 2
+  fi
   status "restart.sh: stopping gateway (PID $OLD_PID, port $PORT)"
   kill "$OLD_PID" 2>/dev/null || true
   i=0

--- a/scripts/live-probe.mjs
+++ b/scripts/live-probe.mjs
@@ -13,7 +13,7 @@ const port = instance.server.address().port;
 // base URL like Codex does, not the bare /v1 path. The suffix stays `/v1/...`
 // on each call, so the prefix is `/c/<key>` without the trailing `/v1`.
 const baseUrl = `http://127.0.0.1:${port}/c/${instance.services.callerKey}`;
-const mcpUrl = `http://127.0.0.1:${port}/mcp`;
+const mcpUrl = `${baseUrl}/mcp`;
 const result = { baseUrl, responses: {}, mcp: {}, web: {}, vision: {} };
 let client;
 

--- a/scripts/mcp-call.mjs
+++ b/scripts/mcp-call.mjs
@@ -2,8 +2,8 @@
 //
 // Use this when the Codex session's MCP connection is unavailable (for example
 // after a gateway restart, which the Codex client never re-establishes). It
-// bypasses the Codex MCP client and talks straight to the gateway's /mcp
-// endpoint, so the tools work in any session.
+// bypasses the Codex MCP client and talks straight to the gateway's keyed MCP
+// endpoint, so the tools work in any session without exposing a bare route.
 //
 //   node scripts/mcp-call.mjs tools
 //   node scripts/mcp-call.mjs list_mcp_tools

--- a/scripts/restart.ps1
+++ b/scripts/restart.ps1
@@ -44,21 +44,34 @@ if ($listener) {
   # MODELDOCK_STATE_DIR redirect, or the guard reads a file the gateway never wrote.
   $stateDir = if ($env:MODELDOCK_STATE_DIR) { $env:MODELDOCK_STATE_DIR } else { Join-Path $env:USERPROFILE ".modeldock" }
   $ownerFile = Join-Path $stateDir "owner-$port.json"
-  if ((Test-Path $ownerFile) -and (-not $args.Contains("-Force"))) {
+  $forceTakeover = $args -contains "-Force"
+  if (-not $forceTakeover) {
+    $owned = $false
     try {
+      if (-not (Test-Path -LiteralPath $ownerFile)) { throw "owner record is missing" }
       $owner = Get-Content $ownerFile -Raw | ConvertFrom-Json
-      if ($owner.root -and $owner.pid -eq $oldPid) {
-        $ownerRoot = [System.IO.Path]::GetFullPath($owner.root)
-        $thisRoot = [System.IO.Path]::GetFullPath($root)
-        if ($ownerRoot -ne $thisRoot) {
-          Write-Status "ERROR: port $port is owned by a gateway from '$ownerRoot' (PID $oldPid); this script runs from '$thisRoot'."
-          Write-Status "Re-run with -Force to take the port over deliberately."
-          exit 1
-        }
+      $ownerRoot = [System.IO.Path]::GetFullPath([string]$owner.root)
+      $thisRoot = [System.IO.Path]::GetFullPath($root)
+      if ([int]$owner.pid -ne [int]$oldPid -or [int]$owner.port -ne $port -or $ownerRoot -ne $thisRoot) {
+        throw "owner record does not match this listener and install root"
       }
+      $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $oldPid" -ErrorAction Stop
+      $commandLine = [string]$processInfo.CommandLine
+      $sourceEntry = [System.IO.Path]::GetFullPath((Join-Path $root "src\server.mjs"))
+      $bundleEntry = [System.IO.Path]::GetFullPath((Join-Path $root "dist\modeldock.mjs"))
+      $owned = $commandLine.IndexOf($sourceEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+          $commandLine.IndexOf($bundleEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+      if (-not $owned) { throw "listener command does not run this ModelDock install" }
     } catch {
-      # Unreadable owner file: fall through and behave as before.
+      Write-Status "ERROR: refusing to stop PID $oldPid on port $port because ownership could not be verified: $($_.Exception.Message)"
+      Write-Status "Re-run with -Force to take the port over deliberately."
+      exit 2
     }
+  }
+  $currentListener = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($currentListener -and $currentListener.OwningProcess -ne $oldPid -and (-not $forceTakeover)) {
+    Write-Status "ERROR: the listener on port $port changed during ownership verification; refusing to stop it."
+    exit 2
   }
   Write-Status "restart.ps1: stopping gateway (PID $oldPid, port $port)"
   Stop-Process -Id $oldPid -Force

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -106,29 +106,33 @@ check_owner() {
   [ "$FORCE" -eq 0 ] || return 0
   state_dir="${MODELDOCK_STATE_DIR:-$HOME/.modeldock}"
   owner_file="$state_dir/owner-$PORT.json"
-  [ -f "$owner_file" ] || return 0
-  "$NODE_BIN" --input-type=module - "$owner_file" "$OLD_PID" "$ROOT" <<'NODE'
+  "$NODE_BIN" --input-type=module - "$owner_file" "$OLD_PID" "$ROOT" "$PORT" <<'NODE'
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-const [ownerFile, oldPid, root] = process.argv.slice(2);
+const [ownerFile, oldPid, root, port] = process.argv.slice(2);
 try {
   const owner = JSON.parse(fs.readFileSync(ownerFile, "utf8"));
-  if (owner?.root && Number(owner.pid) === Number(oldPid)) {
-    const ownerRoot = path.resolve(owner.root);
-    const thisRoot = path.resolve(root);
-    if (ownerRoot !== thisRoot) {
-      const first = `ERROR: port ${owner.port || ""} is owned by a gateway from '${ownerRoot}' (PID ${oldPid}); this script runs from '${thisRoot}'.`;
-      const second = "Re-run with --force to take the port over deliberately.";
-      console.log(first);
-      console.log(second);
-      console.error(first);
-      console.error(second);
-      process.exit(2);
-    }
+  const ownerRoot = path.resolve(String(owner?.root || ""));
+  const thisRoot = path.resolve(root);
+  if (Number(owner?.pid) !== Number(oldPid) || Number(owner?.port) !== Number(port) || ownerRoot !== thisRoot) {
+    throw new Error("owner record does not match this listener and install root");
   }
-} catch {
-  // Unreadable owner file: match restart.ps1 and behave as before.
+  const candidates = [path.join(thisRoot, "src", "server.mjs"), path.join(thisRoot, "dist", "modeldock.mjs")];
+  let commandMatches = false;
+  if (process.platform === "linux") {
+    const argv = fs.readFileSync(`/proc/${oldPid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+    commandMatches = argv.some((arg) => candidates.includes(path.resolve(arg)));
+  } else {
+    const command = execFileSync("ps", ["-p", oldPid, "-o", "command="], { encoding: "utf8" });
+    commandMatches = candidates.some((candidate) => command.includes(candidate));
+  }
+  if (!commandMatches) throw new Error("listener command does not run this ModelDock install");
+} catch (error) {
+  console.error(`ERROR: refusing to stop PID ${oldPid} on port ${port} because ownership could not be verified: ${error.message}`);
+  console.error("Re-run with --force to take the port over deliberately.");
+  process.exit(2);
 }
 NODE
 }
@@ -173,6 +177,11 @@ if try_launchd_restart; then
 fi
 
 if [ -n "$OLD_PID" ]; then
+  current_pid="$(find_listener_pid)"
+  if [ "$FORCE" -eq 0 ] && [ -n "$current_pid" ] && [ "$current_pid" != "$OLD_PID" ]; then
+    status "ERROR: the listener on port $PORT changed during ownership verification; refusing to stop it"
+    exit 2
+  fi
   status "restart.sh: stopping gateway (PID $OLD_PID, port $PORT)"
   kill "$OLD_PID" 2>/dev/null || true
   i=0

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -16,21 +16,39 @@ $runKey = if ($env:MODELDOCK_AUTOSTART_KEY) { $env:MODELDOCK_AUTOSTART_KEY } els
 
 # Stop the gateway: only the pid recorded in the owner file is ours. A listener
 # without a matching owner record is a foreign process - warn and leave it.
-$ownerPid = $null
+$owner = $null
 $ownerFile = Join-Path $stateDir "owner-$port.json"
 if (Test-Path -LiteralPath $ownerFile) {
-    try { $ownerPid = [int]((Get-Content -LiteralPath $ownerFile -Raw | ConvertFrom-Json).pid) } catch { $ownerPid = $null }
+    try { $owner = Get-Content -LiteralPath $ownerFile -Raw | ConvertFrom-Json } catch { $owner = $null }
 }
 $procIds = @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue |
     Select-Object -ExpandProperty OwningProcess -Unique)
 $stopped = 0
 foreach ($procId in $procIds) {
-    if ($ownerPid -and $procId -eq $ownerPid) {
+    $owned = $false
+    try {
+        if (-not $owner) { throw "owner record is missing or unreadable" }
+        $ownerRoot = [System.IO.Path]::GetFullPath([string]$owner.root)
+        $thisRoot = [System.IO.Path]::GetFullPath($root)
+        if ([int]$owner.pid -ne [int]$procId -or [int]$owner.port -ne $port -or $ownerRoot -ne $thisRoot) {
+            throw "owner record does not match this listener and install root"
+        }
+        $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $procId" -ErrorAction Stop
+        $commandLine = [string]$processInfo.CommandLine
+        $sourceEntry = [System.IO.Path]::GetFullPath((Join-Path $root "src\server.mjs"))
+        $bundleEntry = [System.IO.Path]::GetFullPath((Join-Path $root "dist\modeldock.mjs"))
+        $owned = $commandLine.IndexOf($sourceEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
+            $commandLine.IndexOf($bundleEntry, [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+    } catch {
+        $owned = $false
+    }
+    if ($owned) {
         Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
         Write-Output "Stopped gateway process $procId"
         $stopped += 1
     } else {
-        Write-Output "WARNING: port $port is held by pid $procId which is not the recorded ModelDock gateway (owner pid $ownerPid); leaving it alone."
+        $ownerPid = if ($owner) { $owner.pid } else { "unknown" }
+        Write-Output "WARNING: port $port is held by pid $procId which could not be verified as this ModelDock gateway (owner pid $ownerPid); leaving it alone."
     }
 }
 if ($procIds.Count -gt 0 -and $stopped -eq 0) {

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -22,40 +22,57 @@ if [ -f "$OWNER_FILE" ]; then
   OWNER_PID=$(sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$OWNER_FILE" | head -n 1)
 fi
 
-find_listener_pid() {
-  if command -v lsof >/dev/null 2>&1; then
-    lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
-  elif command -v ss >/dev/null 2>&1; then
-    ss -tlnpH "sport = :$PORT" 2>/dev/null | grep -o 'pid=[0-9]*' | head -n 1 | cut -d= -f2 || true
-  elif command -v fuser >/dev/null 2>&1; then
-    fuser "$PORT/tcp" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | head -n 1 || true
-  else
-    true
+find_node() {
+  if [ -n "${MODELDOCK_NODE_PATH:-}" ] && [ -x "$MODELDOCK_NODE_PATH" ]; then
+    printf '%s\n' "$MODELDOCK_NODE_PATH"
+    return
   fi
+  for candidate in "$ROOT"/node/v*/bin/node; do
+    [ -x "$candidate" ] && { printf '%s\n' "$candidate"; return; }
+  done
+  command -v node 2>/dev/null || true
 }
+NODE_BIN="$(find_node)"
 
 # Confirm the recorded PID is really our gateway before killing it: after a reboot
 # the owner file can name a PID that has since been reused by an unrelated process.
-# Accept it only if it is the current listener on our port, or its command line
-# references this install root.
+# The owner fields and the exact gateway entry path must both match.
 owner_is_ours() {
   pid="$1"
-  [ -n "$pid" ] || return 1
-  listener="$(find_listener_pid)"
-  [ -n "$listener" ] && [ "$listener" = "$pid" ] && return 0
-  cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-  case "$cmd" in
-    *"$ROOT"*) return 0 ;;
-    *"$STATE_DIR"*) return 0 ;;
-  esac
-  return 1
+  [ -n "$pid" ] && [ -n "$NODE_BIN" ] || return 1
+  "$NODE_BIN" --input-type=module - "$OWNER_FILE" "$pid" "$ROOT" "$PORT" <<'NODE'
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const [ownerFile, pid, root, port] = process.argv.slice(2);
+try {
+  const owner = JSON.parse(fs.readFileSync(ownerFile, "utf8"));
+  const thisRoot = path.resolve(root);
+  if (Number(owner?.pid) !== Number(pid) || Number(owner?.port) !== Number(port) || path.resolve(String(owner?.root || "")) !== thisRoot) {
+    process.exit(1);
+  }
+  const candidates = [path.join(thisRoot, "src", "server.mjs"), path.join(thisRoot, "dist", "modeldock.mjs")];
+  let matches = false;
+  if (process.platform === "linux") {
+    const argv = fs.readFileSync(`/proc/${pid}/cmdline`).toString("utf8").split("\0").filter(Boolean);
+    matches = argv.some((arg) => candidates.includes(path.resolve(arg)));
+  } else {
+    const command = execFileSync("ps", ["-p", pid, "-o", "command="], { encoding: "utf8" });
+    matches = candidates.some((candidate) => command.includes(candidate));
+  }
+  process.exit(matches ? 0 : 1);
+} catch {
+  process.exit(1);
+}
+NODE
 }
 
 if [ -n "$OWNER_PID" ] && kill -0 "$OWNER_PID" 2>/dev/null && owner_is_ours "$OWNER_PID"; then
   kill "$OWNER_PID" 2>/dev/null || true
   echo "Stopped gateway process $OWNER_PID"
 elif [ -n "$OWNER_PID" ] && kill -0 "$OWNER_PID" 2>/dev/null; then
-  echo "WARNING: recorded PID $OWNER_PID is not listening on port $PORT and does not look like this install; not killing (possible PID reuse)."
+  echo "WARNING: recorded PID $OWNER_PID could not be verified as this install; not killing (possible PID reuse)."
 else
   echo "WARNING: no live ModelDock-owned gateway found on port $PORT; nothing was stopped."
 fi

--- a/src/caller-key.mjs
+++ b/src/caller-key.mjs
@@ -97,5 +97,9 @@ export function loadOrCreateCallerKey(filePath = keyFilePath()) {
 }
 
 export function callerBasePath(key) {
-  return `${CALLER_PATH_PREFIX}/${key}/v1`;
+  return `${callerRootPath(key)}/v1`;
+}
+
+export function callerRootPath(key) {
+  return `${CALLER_PATH_PREFIX}/${key}`;
 }

--- a/src/config-switcher.test.mjs
+++ b/src/config-switcher.test.mjs
@@ -26,7 +26,7 @@ async function fixture(t) {
     switcher: new CodexConfigSwitcher({
       codexHome,
       baseUrl: "http://127.0.0.1:4097/v1",
-      mcpUrl: "http://127.0.0.1:4097/mcp",
+      mcpUrl: "http://127.0.0.1:4097/c/test-caller-key/mcp",
       model: "deepseek-v4-flash",
     }),
   };
@@ -37,7 +37,7 @@ test("managed config keeps the built-in provider and redirects its base URL", ()
     baseUrl: "http://127.0.0.1:4097/c/callerkey/v1",
     model: "deepseek-v4-flash",
     catalogFile: "C:/Users/x/.modeldock/codex-model-catalog.json",
-    mcpUrl: "http://127.0.0.1:4097/mcp",
+    mcpUrl: "http://127.0.0.1:4097/c/test-caller-key/mcp",
   });
   assert.match(managed, /^model = "deepseek-v4-flash"/m);
   assert.match(managed, /^openai_base_url = "http:\/\/127\.0\.0\.1:4097\/c\/callerkey\/v1"$/m);
@@ -52,7 +52,7 @@ test("managed config keeps the built-in provider and redirects its base URL", ()
   assert.match(managed, /\[features\]\nmulti_agent = true/);
   assert.match(managed, /\[mcp_servers\.docs\]/);
   assert.match(managed, /\[mcp_servers\.modeldock\]\n# Managed by ModelDock: web_search_exa/);
-  assert.match(managed, /url = "http:\/\/127\.0\.0\.1:4097\/mcp"/);
+  assert.match(managed, /url = "http:\/\/127\.0\.0\.1:4097\/c\/test-caller-key\/mcp"/);
   // The managed keys must stay above the first table so the TOML stays valid.
   const table = managed.indexOf("[features]");
   const openaiBase = managed.indexOf("openai_base_url");
@@ -73,12 +73,12 @@ test("managed config writes the stdio bridge when mcpCommand is set", () => {
     model: "deepseek-v4-flash",
     mcpCommand: "C:/Program Files/nodejs/node.exe",
     mcpArgs: ["D:/projects/modeldock/src/mcp-standalone.mjs"],
-    mcpEnv: { MODELDOCK_GATEWAY_URL: "http://127.0.0.1:4097" },
+    mcpEnv: { MODELDOCK_GATEWAY_URL: "http://127.0.0.1:4097/c/test-caller-key" },
   });
   assert.match(managed, /\[mcp_servers\.modeldock\]/);
   assert.match(managed, /command = "C:\/Program Files\/nodejs\/node\.exe"/);
   assert.match(managed, /args = \["D:\/projects\/modeldock\/src\/mcp-standalone\.mjs"\]/);
-  assert.match(managed, /env = \{ "MODELDOCK_GATEWAY_URL" = "http:\/\/127\.0\.0\.1:4097" \}/);
+  assert.match(managed, /env = \{ "MODELDOCK_GATEWAY_URL" = "http:\/\/127\.0\.0\.1:4097\/c\/test-caller-key" \}/);
   assert.doesNotMatch(
     managed,
     /\[mcp_servers\.modeldock\][\s\S]*?^url = /m,

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -363,7 +363,7 @@ export function loadConfig() {
   };
   // How the managed [mcp_servers.modeldock] entry connects: "stdio" (default) spawns
   // src/mcp-standalone.mjs as a Codex-owned child that survives gateway restarts;
-  // "url" points Codex at the gateway's own streamable-HTTP /mcp endpoint instead.
+  // "url" points Codex at the gateway's caller-key-protected HTTP MCP endpoint instead.
   const mcpTransportRaw = (process.env.MODELDOCK_MCP_TRANSPORT || "stdio").trim().toLowerCase();
   const mcpTransport = ["stdio", "url"].includes(mcpTransportRaw) ? mcpTransportRaw : "stdio";
 

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -157,10 +157,17 @@ function endRelayStreamFailure(res, message) {
 // images endpoints answer application/json - ends with a JSON error object.
 // Writing SSE events into an application/json body leaves the client with a
 // body it cannot parse.
-function endRelayFailure(res, message) {
+function endRelayFailure(res, message, bodyStarted = false) {
   const contentType = String(res.getHeader?.("Content-Type") || "");
   if (/text\/event-stream/i.test(contentType) || /ndjson|jsonl/i.test(contentType)) {
     endRelayStreamFailure(res, message);
+    return;
+  }
+  // Once any JSON bytes have reached the client there is no valid error object
+  // we can append. Reset the response so clients see a transport failure instead
+  // of accepting a syntactically corrupt 200 body.
+  if (bodyStarted) {
+    res.destroy();
     return;
   }
   try {
@@ -693,7 +700,7 @@ function usageFromEvent(event) {
 // emits "close" without "finish" or "error"; without that handler the promise
 // never settles and the request stays counted as in-flight forever, with the
 // upstream body still being read.
-export async function pipeGatewayStream(upstreamBody, res, tee, onFirstResponse) {
+export async function pipeGatewayStream(upstreamBody, res, tee, onFirstResponse, onChunk) {
   if (!upstreamBody) {
     res.end();
     return { bytes: 0, interrupted: false };
@@ -716,7 +723,9 @@ export async function pipeGatewayStream(upstreamBody, res, tee, onFirstResponse)
         onFirstResponse?.();
       }
       tee?.push(chunk);
-      bytes += chunk.byteLength || Buffer.byteLength(chunk);
+      const size = chunk.byteLength || Buffer.byteLength(chunk);
+      bytes += size;
+      onChunk?.(size);
     });
     stream.once("end", () => tee?.end?.());
     stream.once("error", settle);
@@ -1039,6 +1048,7 @@ export async function relayNativeImage(payload, res, services, { signal } = {}) 
   const body = typeof payload === "string" || Buffer.isBuffer(payload)
     ? payload
     : JSON.stringify(payload || {});
+  let forwardedBytes = 0;
   try {
     const upstream = await fetch(target, {
       method: "POST",
@@ -1061,7 +1071,9 @@ export async function relayNativeImage(payload, res, services, { signal } = {}) 
       res.setHeader("Cache-Control", "no-cache, no-transform");
       res.flushHeaders();
     }
-    const piped = await pipeGatewayStream(upstream.body, res, null);
+    const piped = await pipeGatewayStream(upstream.body, res, null, null, (size) => {
+      forwardedBytes += size;
+    });
     if (piped.interrupted) {
       return { ok: false, httpStatus: 499, error: "client disconnected" };
     }
@@ -1072,7 +1084,7 @@ export async function relayNativeImage(payload, res, services, { signal } = {}) 
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: { type: "upstream_failed", message: redactBearer(error.message) } }));
     } else {
-      endRelayFailure(res, redactBearer(error.message));
+      endRelayFailure(res, redactBearer(error.message), forwardedBytes > 0);
     }
     return { ok: false, httpStatus: 502, error: error.message };
   }

--- a/src/gateway.test.mjs
+++ b/src/gateway.test.mjs
@@ -1062,7 +1062,7 @@ test("relayNativeImage forwards image generation to the native backend", async (
   }
 });
 
-test("relayNativeImage ends a mid-stream upstream failure as JSON, not SSE", async () => {
+test("relayNativeImage resets a JSON response after partial bytes were forwarded", async () => {
   const sink = collectStream();
   const res = responseStub(sink);
   const originalFetch = globalThis.fetch;
@@ -1072,7 +1072,7 @@ test("relayNativeImage ends a mid-stream upstream failure as JSON, not SSE", asy
         start(controller) {
           // A partial image JSON body, then the upstream connection dies.
           controller.enqueue(Buffer.from('{"data":[{"b64_json":"'));
-          controller.error(new Error("image burst Bearer sk-abc123456"));
+          setTimeout(() => controller.error(new Error("image burst Bearer sk-abc123456")), 20);
         },
       }),
       { status: 200, headers: { "content-type": "application/json" } },
@@ -1086,10 +1086,33 @@ test("relayNativeImage ends a mid-stream upstream failure as JSON, not SSE", asy
     );
     assert.equal(result.ok, false);
     const forwarded = Buffer.concat(sink.chunks).toString("utf8");
-    assert.doesNotMatch(forwarded, /event: response\.failed/, "SSE events must not ride in a JSON response");
-    assert.match(forwarded, /"type":"upstream_failed"/);
-    assert.match(forwarded, /image burst/, "the failure reason reaches the client");
-    assert.doesNotMatch(forwarded, /sk-abc123456/, "bearer tokens are redacted");
+    assert.equal(sink.destroyed, true, "a partial JSON response must be reset");
+    assert.equal(forwarded, '{"data":[{"b64_json":"', "no synthetic payload may be appended to partial JSON");
+    assert.doesNotMatch(forwarded, /response\.failed|upstream_failed|sk-abc123456/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayNativeImage emits a valid JSON error when upstream fails before body bytes", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(
+    new ReadableStream({ start(controller) { controller.error(new Error("empty burst Bearer sk-abc123456")); } }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+  try {
+    const result = await relayNativeImage(
+      { model: "gpt-image-2", prompt: "boom", size: "1024x1024" },
+      res,
+      { incomingHeaders: {}, requestUrl: "/c/key123/v1/images/generations" },
+    );
+    assert.equal(result.ok, false);
+    const parsed = JSON.parse(Buffer.concat(sink.chunks).toString("utf8"));
+    assert.equal(parsed.error.type, "upstream_failed");
+    assert.match(parsed.error.message, /empty burst/);
+    assert.doesNotMatch(parsed.error.message, /sk-abc123456/);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/mcp-client.mjs
+++ b/src/mcp-client.mjs
@@ -5,10 +5,13 @@
 // is needed. This module is shared by the stdio bridge (src/mcp-standalone.mjs)
 // and the direct CLI (scripts/mcp-call.mjs).
 
+import { callerRootPath, loadOrCreateCallerKey } from "./caller-key.mjs";
+
 const DEFAULT_GATEWAY_URL = "http://127.0.0.1:4097";
 
 export function gatewayBaseUrl() {
-  return process.env.MODELDOCK_GATEWAY_URL || DEFAULT_GATEWAY_URL;
+  return process.env.MODELDOCK_GATEWAY_URL
+    || `${DEFAULT_GATEWAY_URL}${callerRootPath(loadOrCreateCallerKey())}`;
 }
 
 export async function requestMcp(baseUrl, method, params) {

--- a/src/mcp-standalone.mjs
+++ b/src/mcp-standalone.mjs
@@ -4,7 +4,7 @@
 // by src/config-switcher.mjs uses command/args instead of url), so its lifetime
 // is owned by Codex and gateway restarts never kill it. Tools are registered
 // locally - tools/list works even while the gateway is down - while web search
-// and vision calls are forwarded to the gateway's /mcp endpoint. Speech tools
+// and vision calls are forwarded to the gateway's keyed MCP endpoint. Speech tools
 // (speak/hear) run fully local and never touch the gateway.
 //
 // Never write to stdout outside the MCP protocol: stdout is the transport.

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -19,7 +19,7 @@ import { CodexConfigSwitcher } from "./config-switcher.mjs";
 import { createAutostart } from "./autostart.mjs";
 import { createUpdater, localVersion } from "./update.mjs";
 import { clearOwnerFile, describeOwnerConflict, writeOwnerFile } from "./instance-owner.mjs";
-import { CALLER_PATH_PREFIX, callerBasePath, callerKeyEqual, loadOrCreateCallerKey } from "./caller-key.mjs";
+import { CALLER_PATH_PREFIX, callerBasePath, callerKeyEqual, callerRootPath, loadOrCreateCallerKey } from "./caller-key.mjs";
 import { validateProviderToken } from "./token-validate.mjs";
 import { RouteAffinity } from "./router.mjs";
 import { PROVIDER_SEPARATOR, applyCustomProfile, bareModelId, profileOptions, profileById, providerForModel, publishedSlugFor, tokenFor, TRIAL_MAIN_MODEL, TRIAL_VISION_MODEL } from "./profiles.mjs";
@@ -327,9 +327,8 @@ function configMutationGuard(config) {
 // browsers and send no Origin header. Reject any request that DOES carry a
 // cross-origin Origin so a malicious web page (or a DNS-rebinding attack that
 // makes itself same-host) cannot drive vision_inspect/speak against this loopback
-// gateway. A full caller-key on /mcp would also stop non-browser local processes;
-// that is a larger change (the base URL written into config.toml would have to
-// carry the key) and is tracked separately.
+// gateway. The route also carries the caller capability key; Origin filtering
+// remains useful defense in depth for browser callers that somehow learn it.
 function crossOriginGuard(config) {
   const allowedOrigins = new Set([
     `http://${urlHost(config.host)}:${config.port}`,
@@ -713,10 +712,11 @@ export function createServices(config = loadConfig()) {
   // The capability key rides in the base URL Codex reads from config.toml, so a
   // hostile local web page cannot reach the relay endpoints (see caller-key.mjs).
   const callerKey = mutableConfig.callerKey || loadOrCreateCallerKey();
-  const mcpUrl = `http://${urlHost(mutableConfig.host)}:${mutableConfig.port}/mcp`;
+  const gatewayUrl = `http://${urlHost(mutableConfig.host)}:${mutableConfig.port}`;
+  const mcpUrl = `${gatewayUrl}${callerRootPath(callerKey)}/mcp`;
   const configSwitcher = new CodexConfigSwitcher({
     codexHome: mutableConfig.codexHome,
-    baseUrl: `http://${urlHost(mutableConfig.host)}:${mutableConfig.port}${callerBasePath(callerKey)}`,
+    baseUrl: `${gatewayUrl}${callerBasePath(callerKey)}`,
     // stdio (default) spawns the standalone bridge as a Codex-owned child so gateway
     // restarts never kill the session's MCP tools; url keeps the old HTTP wiring.
     mcpUrl: mutableConfig.mcpTransport === "url" ? mcpUrl : "",
@@ -896,7 +896,6 @@ export function createApp(services = createServices()) {
     },
   });
 
-  app.all("/mcp", crossOriginGuard(config), (req, res) => mcpHandler(req, res, req.body));
   // Capability-key routes: the base_url written into config.toml carries the key
   // (/c/<key>/v1), so Codex authenticates implicitly while a hostile local web
   // page (which can POST to loopback but cannot read ~/.modeldock) cannot.
@@ -904,6 +903,11 @@ export function createApp(services = createServices()) {
     if (services.callerKey && callerKeyEqual(req.params.key, services.callerKey)) return next();
     return res.status(401).json({ error: { type: "invalid_caller_key", message: "Unknown caller key; re-enable the Codex switch to refresh the URL." } });
   };
+  const guardMcpOrigin = crossOriginGuard(config);
+  app.all(`${CALLER_PATH_PREFIX}/:key/mcp`, guardMcpOrigin, requireCallerKey, (req, res) => mcpHandler(req, res, req.body));
+  app.all("/mcp", guardMcpOrigin, (_req, res) => res.status(401).json({
+    error: { type: "caller_key_required", message: "This MCP endpoint requires the keyed URL; re-enable the Codex switch." },
+  }));
   app.post(`${CALLER_PATH_PREFIX}/:key/v1/responses`, requireCallerKey, (req, res) => relayGatewayRequest(req, res, services));
   app.post(`${CALLER_PATH_PREFIX}/:key/v1/responses/compact`, requireCallerKey, (req, res) => relayGatewayRequest(req, res, services));
   app.post(`${CALLER_PATH_PREFIX}/:key/responses/compact`, requireCallerKey, (req, res) => relayGatewayRequest(req, res, services));
@@ -1444,7 +1448,7 @@ if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToP
   console.log(`ModelDock OpenCode Go gate listening at ${instance.url}`);
   console.log(`Dashboard: ${instance.url}/`);
   console.log(`Responses: ${instance.url}/v1/responses`);
-  console.log(`MCP: ${instance.url}/mcp`);
+  console.log("MCP: caller-key-protected endpoint configured for Codex");
   const missingTokens = Object.entries(instance.services.config.tokens || { "opencode-go": instance.services.config.goToken })
     .filter(([, token]) => !token)
     .map(([provider]) => provider);

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -186,15 +186,19 @@ function writeStagedFile(body, target) {
   return tmp;
 }
 
-// Replace the platform layout as one recoverable set. Every new file and every
-// backup is prepared before the first destination changes. If any replacement
-// fails, all destinations already changed in this pass are restored before the
-// error reaches the API, so an update can never leave a new bundle beside old
-// launch/recovery scripts.
-function deployFilesAtomically(items, rootDir) {
+// Replace the platform layout as one recoverable set. The complete rollback
+// snapshot and its durable marker are committed before the first destination
+// changes, so both thrown errors and process/machine crashes are recoverable.
+export function deployFilesAtomically(items, rootDir, { afterReplace } = {}) {
   const prepared = [];
   let applied = 0;
   let rollbackDir = "";
+  let rollbackStageDir = "";
+  let rollbackRoot = "";
+  let marker = "";
+  let markerStage = "";
+  let markerCommitted = false;
+  let previousMarker;
   try {
     for (const item of items) {
       if (existsSync(item.dest) && !statSync(item.dest).isFile()) {
@@ -209,17 +213,19 @@ function deployFilesAtomically(items, rootDir) {
       if (existed) copyFileSync(item.dest, backup);
     }
 
-    for (const item of prepared) {
-      renameSync(item.stage, item.dest);
-      applied += 1;
-    }
-
     // Preserve the entire previous platform layout, not just the bundle. A new
     // bundle can depend on its matching bridge and lifecycle scripts, so runtime
-    // recovery must restore the same version set as one transaction.
-    const rollbackRoot = path.join(rootDir, ".modeldock-rollback");
+    // recovery must restore the same version set as one transaction. This is
+    // deliberately durable before any destination rename: if the updater dies
+    // mid-deployment, recover.* can still identify and restore the old layout.
+    rollbackRoot = path.join(rootDir, ".modeldock-rollback");
     const rollbackName = `${Date.now()}-${process.pid}`;
     rollbackDir = path.join(rollbackRoot, rollbackName);
+    rollbackStageDir = `${rollbackDir}.tmp`;
+    marker = path.join(rollbackRoot, "current");
+    markerStage = `${marker}.${process.pid}.tmp`;
+    previousMarker = existsSync(marker) ? readFileSync(marker, "utf8") : undefined;
+    mkdirSync(rollbackStageDir, { recursive: true });
     const files = [];
     for (const item of prepared) {
       const relative = path.relative(rootDir, item.dest).replaceAll(path.sep, "/");
@@ -228,17 +234,22 @@ function deployFilesAtomically(items, rootDir) {
       }
       files.push({ path: relative, existed: item.existed });
       if (item.existed) {
-        const rollbackFile = path.join(rollbackDir, ...relative.split("/"));
+        const rollbackFile = path.join(rollbackStageDir, ...relative.split("/"));
         mkdirSync(path.dirname(rollbackFile), { recursive: true });
         copyFileSync(item.backup, rollbackFile);
       }
     }
-    mkdirSync(rollbackDir, { recursive: true });
-    writeFileSync(path.join(rollbackDir, "manifest.json"), `${JSON.stringify({ files }, null, 2)}\n`, "utf8");
-    const marker = path.join(rollbackRoot, "current");
-    const markerStage = `${marker}.${process.pid}.tmp`;
+    writeFileSync(path.join(rollbackStageDir, "manifest.json"), `${JSON.stringify({ files }, null, 2)}\n`, "utf8");
+    renameSync(rollbackStageDir, rollbackDir);
     writeFileSync(markerStage, `${rollbackName}\n`, "utf8");
     renameSync(markerStage, marker);
+    markerCommitted = true;
+
+    for (const item of prepared) {
+      renameSync(item.stage, item.dest);
+      applied += 1;
+      afterReplace?.(applied, item);
+    }
 
     // Prune old snapshots now that the new marker is committed: the marker
     // always points at the newest snapshot, so older ones are unreachable
@@ -274,13 +285,37 @@ function deployFilesAtomically(items, rootDir) {
     }
     for (const item of prepared) {
       try { removeFileIfPresent(item.stage); } catch { /* report the primary failure */ }
-      try { removeFileIfPresent(item.backup); } catch { /* report the primary failure */ }
+    }
+    try { if (markerStage) removeFileIfPresent(markerStage); } catch { /* report the primary failure */ }
+    // If an in-process rollback itself failed, keep the new marker, complete
+    // snapshot, and adjacent backups intact. The recovery script can then
+    // finish restoring the old layout instead of losing the only good copies.
+    if (rollbackErrors.length) {
+      throw new Error(`${error.message}; rollback failed: ${rollbackErrors.join("; ")}`);
+    }
+    for (const item of prepared) {
+      try { removeFileIfPresent(item.backup); } catch { /* restored layout is already safe */ }
+    }
+    if (markerCommitted) {
+      try {
+        if (previousMarker === undefined) {
+          removeFileIfPresent(marker);
+        } else {
+          writeFileSync(markerStage, previousMarker, "utf8");
+          renameSync(markerStage, marker);
+        }
+      } catch (rollbackError) {
+        rollbackErrors.push(`${marker}: ${rollbackError.message}`);
+      }
+    }
+    if (rollbackErrors.length) {
+      throw new Error(`${error.message}; rollback metadata restore failed: ${rollbackErrors.join("; ")}`);
     }
     if (rollbackDir) {
       try { rmSync(rollbackDir, { recursive: true, force: true }); } catch { /* unreferenced partial snapshot */ }
     }
-    if (rollbackErrors.length) {
-      throw new Error(`${error.message}; rollback failed: ${rollbackErrors.join("; ")}`);
+    if (rollbackStageDir) {
+      try { rmSync(rollbackStageDir, { recursive: true, force: true }); } catch { /* unreferenced partial snapshot */ }
     }
     throw error;
   }

--- a/src/update.test.mjs
+++ b/src/update.test.mjs
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { compareVersions, parseLatestRelease, parseSumsFile, localVersion, createUpdater } from "./update.mjs";
+import { compareVersions, parseLatestRelease, parseSumsFile, localVersion, createUpdater, deployFilesAtomically } from "./update.mjs";
 
 function responseBody(body) {
   const bytes = Buffer.from(body);
@@ -296,6 +297,75 @@ test("createUpdater.apply rolls back the whole layout when a destination cannot 
   for (const [relative, body] of Object.entries(original)) {
     assert.equal(readFileSync(path.join(rootDir, relative), "utf8"), body, `${relative} must be rolled back`);
   }
+});
+
+test("deployFilesAtomically arms a complete rollback snapshot before the first replacement", (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-crash-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, "scripts"));
+  writeFileSync(path.join(rootDir, "dist/modeldock.mjs"), "old bundle");
+  writeFileSync(path.join(rootDir, "scripts/restart.ps1"), "old restart");
+  const moduleUrl = new URL("./update.mjs", import.meta.url).href;
+  const childScript = `
+    import path from "node:path";
+    import { deployFilesAtomically } from ${JSON.stringify(moduleUrl)};
+    const root = process.argv[1];
+    deployFilesAtomically([
+      { body: Buffer.from("new bundle"), dest: path.join(root, "dist/modeldock.mjs") },
+      { body: Buffer.from("new restart"), dest: path.join(root, "scripts/restart.ps1") },
+    ], root, { afterReplace(count) { if (count === 1) process.exit(73); } });
+  `;
+  const child = spawnSync(process.execPath, ["--input-type=module", "-e", childScript, rootDir]);
+  assert.equal(child.status, 73);
+  assert.equal(readFileSync(path.join(rootDir, "dist/modeldock.mjs"), "utf8"), "new bundle");
+  assert.equal(readFileSync(path.join(rootDir, "scripts/restart.ps1"), "utf8"), "old restart");
+  const rollbackRoot = path.join(rootDir, ".modeldock-rollback");
+  const current = readFileSync(path.join(rollbackRoot, "current"), "utf8").trim();
+  const snapshot = path.join(rollbackRoot, current);
+  const manifest = JSON.parse(readFileSync(path.join(snapshot, "manifest.json"), "utf8"));
+  assert.deepEqual(manifest.files.map((entry) => entry.path), ["dist/modeldock.mjs", "scripts/restart.ps1"]);
+  assert.equal(readFileSync(path.join(snapshot, "dist/modeldock.mjs"), "utf8"), "old bundle");
+  assert.equal(readFileSync(path.join(snapshot, "scripts/restart.ps1"), "utf8"), "old restart");
+  assert.equal(readdirSync(rollbackRoot).some((name) => name.endsWith(".tmp")), false);
+});
+
+test("deployFilesAtomically restores the prior marker after an in-process replacement failure", (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-marker-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  mkdirSync(path.join(rootDir, "dist"));
+  mkdirSync(path.join(rootDir, ".modeldock-rollback", "100-1"), { recursive: true });
+  writeFileSync(path.join(rootDir, ".modeldock-rollback", "current"), "100-1\n");
+  writeFileSync(path.join(rootDir, "dist/modeldock.mjs"), "old bundle");
+  assert.throws(() => deployFilesAtomically(
+    [{ body: Buffer.from("new bundle"), dest: path.join(rootDir, "dist/modeldock.mjs") }],
+    rootDir,
+    { afterReplace() { throw new Error("injected replacement failure"); } },
+  ), /injected replacement failure/);
+  assert.equal(readFileSync(path.join(rootDir, "dist/modeldock.mjs"), "utf8"), "old bundle");
+  assert.equal(readFileSync(path.join(rootDir, ".modeldock-rollback", "current"), "utf8"), "100-1\n");
+  assert.deepEqual(readdirSync(path.join(rootDir, ".modeldock-rollback")).sort(), ["100-1", "current"]);
+});
+
+test("deployFilesAtomically preserves recovery material when in-process rollback fails", (t) => {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "modeldock-update-rollback-failure-"));
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+  mkdirSync(path.join(rootDir, "dist"));
+  const destination = path.join(rootDir, "dist/modeldock.mjs");
+  writeFileSync(destination, "old bundle");
+  assert.throws(() => deployFilesAtomically(
+    [{ body: Buffer.from("new bundle"), dest: destination }],
+    rootDir,
+    { afterReplace() {
+      rmSync(`${destination}.${process.pid}.update-backup`);
+      throw new Error("injected failure after replacement");
+    } },
+  ), /rollback failed/);
+  assert.equal(readFileSync(destination, "utf8"), "new bundle", "the failed in-process restore remains visible");
+  const rollbackRoot = path.join(rootDir, ".modeldock-rollback");
+  const current = readFileSync(path.join(rollbackRoot, "current"), "utf8").trim();
+  assert.equal(readFileSync(path.join(rollbackRoot, current, "dist/modeldock.mjs"), "utf8"), "old bundle");
+  assert.ok(readFileSync(path.join(rollbackRoot, current, "manifest.json"), "utf8").includes("dist/modeldock.mjs"));
 });
 
 test("createUpdater.apply rolls back when the complete rollback snapshot cannot be written", async (t) => {

--- a/test/install-mock.test.mjs
+++ b/test/install-mock.test.mjs
@@ -209,14 +209,15 @@ async function assertRoutingWorks(port, upstreamTag, callerKey) {
   assert.match(text, new RegExp(upstreamTag), `relay should carry the upstream output through`);
 }
 
-async function assertGatewayMcpTools(port) {
-  const init = await rpcMcp(`http://127.0.0.1:${port}`, "initialize", {
+async function assertGatewayMcpTools(port, callerKey) {
+  const gatewayMcpBase = `http://127.0.0.1:${port}/c/${callerKey}`;
+  const init = await rpcMcp(gatewayMcpBase, "initialize", {
     protocolVersion: "2025-06-18",
     capabilities: {},
     clientInfo: { name: "install-test", version: "1.0.0" },
   });
   assert.equal(init.status, 200, "MCP initialize should succeed against the installed gateway");
-  const listed = await rpcMcp(`http://127.0.0.1:${port}`, "tools/list", {});
+  const listed = await rpcMcp(gatewayMcpBase, "tools/list", {});
   const names = (listed.parsed?.result?.tools || []).map((tool) => tool.name);
   for (const name of ["web_search_exa", "vision_inspect", "speak", "hear", "recall_memory", "store_memory"]) {
     assert.ok(names.includes(name), `${name} missing from installed gateway MCP tools: ${names.join(",")}`);
@@ -738,13 +739,13 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
   // 5b. The surfaces a real session depends on must be live after install: the
   //     MCP tool list (HTTP /mcp + the stdio bridge Codex spawns), and the catalog
   //     declarations the LLM reads for its tool surface.
-  await assertGatewayMcpTools(appPort);
-  await assertBridgeTools(path.join(installDir, "dist", "mcp-standalone.mjs"), `http://127.0.0.1:${appPort}`, memoryDir);
+  const callerKey = readCallerKey(path.join(installDir, ".modeldock"));
+  await assertGatewayMcpTools(appPort, callerKey);
+  await assertBridgeTools(path.join(installDir, "dist", "mcp-standalone.mjs"), `http://127.0.0.1:${appPort}/c/${callerKey}`, memoryDir);
   assertCatalogTools(installedCatalog);
   // Caller-key enforcement is on by default, so routing must go through the
   // keyed /c/<key>/v1 URL (what the managed Codex config points at) while the
   // bare path is rejected.
-  const callerKey = readCallerKey(path.join(installDir, ".modeldock"));
   await assertRoutingWorks(appPort, "modeldock-relay-ok", callerKey);
   const bare = await relayProbe(appPort, "");
   assert.equal(bare.status, 401, "bare /v1 relay should be rejected when caller-key enforcement is on by default");
@@ -803,7 +804,7 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
   assert.ok(secondHealth.up, `gateway should come up on second start\n${secondOut}\n${secondErr}`);
   assert.equal(secondHealth.status, 200);
   await assertRoutingWorks(appPort, "modeldock-relay-ok", callerKey);
-  await assertGatewayMcpTools(appPort);
+  await assertGatewayMcpTools(appPort, callerKey);
   assertCatalogTools(installedCatalog);
 
   // 8. Login relaunch: start through the exact entry the OS uses at login. Windows
@@ -841,7 +842,7 @@ test("mock install lifecycle: first start, second start routes, login relaunch",
   assert.ok(relaunchHealth.up, `gateway should come up through the login entry\n${relaunchOut}\n${relaunchErr}`);
   assert.equal(relaunchHealth.status, 200);
   await assertRoutingWorks(appPort, "modeldock-relay-ok", callerKey);
-  await assertGatewayMcpTools(appPort);
+  await assertGatewayMcpTools(appPort, callerKey);
 
   // 9. Stop the final gateway so cleanup can remove the temp install dir.
   killByPort(appPort);
@@ -1118,9 +1119,19 @@ test("uninstall preserves the memory vault and never kills a foreign listener", 
   const probe = createServer();
   const port = await listen(probe);
   await new Promise((resolve) => probe.close(resolve));
-  // A recorded owner that is not a listener on the port must never be killed.
-  // 2147483647 is the largest possible pid and cannot be alive on any runner.
-  writeFileSync(ownerFilePath(port, root), JSON.stringify({ pid: 2147483647, root, port }));
+  // Forge a stale owner record around a real foreign listener. PID and port
+  // equality alone must not authorize a kill after PID reuse; the process must
+  // also run this install's exact gateway entry path.
+  const foreign = spawn(process.execPath, ["--input-type=module", "-e", `
+import http from "node:http";
+http.createServer((req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ ok: true, foreign: true }));
+}).listen(Number(process.env.MODELDOCK_PORT), "127.0.0.1");
+`], { env: { ...process.env, MODELDOCK_PORT: String(port) }, stdio: "ignore" });
+  t.after(() => foreign.kill("SIGKILL"));
+  assert.ok((await waitForHealth(port)).up, "foreign listener should start");
+  writeFileSync(ownerFilePath(port, root), JSON.stringify({ pid: foreign.pid, root: repoRoot, port }));
 
   const env = {
     ...process.env,
@@ -1145,6 +1156,7 @@ test("uninstall preserves the memory vault and never kills a foreign listener", 
   assert.ok(!existsSync(path.join(stateDir, "caller-key")), "runtime state files should be cleared");
   assert.ok(!existsSync(path.join(stateDir, "autostart-initialized")), "the autostart mark should be cleared");
   assert.match(out + err, /preserved/i, "uninstall should say the memory vault is preserved");
+  assert.ok((await waitForHealth(port)).up, "uninstall must leave the foreign listener running");
 });
 
 test("recover menu repairs a lost autostart Run key", async (t) => {

--- a/test/restart-ps1.test.mjs
+++ b/test/restart-ps1.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function reservePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitForHealth(port) {
+  for (let index = 0; index < 40; index += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (response.ok) return true;
+    } catch {
+      // Still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+}
+
+test("restart.ps1 refuses a live foreign listener when the owner record is missing", async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("restart.ps1 is Windows-only");
+    return;
+  }
+  const root = mkdtempSync(path.join(os.tmpdir(), "modeldock-restart-ps1-"));
+  const stateDir = path.join(root, ".state");
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  mkdirSync(path.join(root, "dist"), { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  const port = await reservePort();
+  writeFileSync(path.join(root, ".env"), `MODELDOCK_PORT=${port}\n`, "utf8");
+  writeFileSync(path.join(root, "scripts", "restart.ps1"), readFileSync(path.join(repoRoot, "scripts", "restart.ps1")), "utf8");
+  writeFileSync(path.join(root, "dist", "modeldock.mjs"), "process.exit(0);\n", "utf8");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const foreign = spawn(process.execPath, ["--input-type=module", "-e", `
+import http from "node:http";
+http.createServer((req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ ok: true, foreign: true }));
+}).listen(Number(process.env.MODELDOCK_PORT), "127.0.0.1");
+`], { env: { ...process.env, MODELDOCK_PORT: String(port) }, stdio: "ignore" });
+  t.after(() => foreign.kill("SIGKILL"));
+  assert.equal(await waitForHealth(port), true, "foreign listener should start");
+
+  const restart = spawn("powershell", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", path.join(root, "scripts", "restart.ps1")], {
+    env: {
+      ...process.env,
+      MODELDOCK_PORT: String(port),
+      MODELDOCK_STATE_DIR: stateDir,
+      MODELDOCK_NODE_PATH: process.execPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  restart.stdout.on("data", (chunk) => (output += chunk));
+  restart.stderr.on("data", (chunk) => (output += chunk));
+  const exitCode = await new Promise((resolve) => restart.on("close", resolve));
+  assert.equal(exitCode, 2, output);
+  assert.match(output, /ownership could not be verified|owner record is missing/i);
+  assert.equal(await waitForHealth(port), true, "foreign listener must survive the refused restart");
+});

--- a/test/restart-sh.test.mjs
+++ b/test/restart-sh.test.mjs
@@ -49,8 +49,36 @@ test("restart.sh stops the owned listener and starts a healthy POSIX gateway", a
 
   writeFileSync(path.join(root, ".env"), `MODELDOCK_PORT=${port}\n`, "utf8");
   writeFileSync(path.join(root, "scripts", "restart.sh"), readFileSync(path.join(repoRoot, "scripts", "restart.sh")), { mode: 0o755 });
+  const bundlePath = path.join(root, "dist", "modeldock.mjs");
   writeFileSync(
-    path.join(root, "dist", "modeldock.mjs"),
+    bundlePath,
+    `import http from "node:http";
+const port = Number(process.env.MODELDOCK_PORT);
+http.createServer((req, res) => {
+  if (req.url === "/healthz") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, marker: "old", pid: process.pid }));
+    return;
+  }
+  res.writeHead(404); res.end();
+}).listen(port, "127.0.0.1");
+`,
+    "utf8",
+  );
+
+  const old = spawn(process.execPath, [bundlePath], {
+    env: { ...process.env, MODELDOCK_PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(() => old.kill("SIGKILL"));
+  const oldHealth = await waitForHealth(port, "old");
+  assert.ok(oldHealth, "old gateway should start for the restart test");
+
+  // Replace the on-disk entry only after the old process loaded it. The command
+  // line still identifies the exact owned bundle while restart launches this
+  // new content from the same path.
+  writeFileSync(
+    bundlePath,
     `import http from "node:http";
 import { writeFileSync } from "node:fs";
 const port = Number(process.env.MODELDOCK_PORT || ${port});
@@ -66,25 +94,6 @@ http.createServer((req, res) => {
 `,
     "utf8",
   );
-
-  const old = spawn(process.execPath, ["--input-type=module", "-e", `
-import http from "node:http";
-const port = Number(process.env.MODELDOCK_PORT);
-http.createServer((req, res) => {
-  if (req.url === "/healthz") {
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ ok: true, marker: "old", pid: process.pid }));
-    return;
-  }
-  res.writeHead(404); res.end();
-}).listen(port, "127.0.0.1");
-`], {
-    env: { ...process.env, MODELDOCK_PORT: String(port) },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  t.after(() => old.kill("SIGKILL"));
-  const oldHealth = await waitForHealth(port, "old");
-  assert.ok(oldHealth, "old gateway should start for the restart test");
 
   writeFileSync(
     path.join(stateDir, `owner-${port}.json`),
@@ -112,4 +121,43 @@ http.createServer((req, res) => {
   } catch {
     // Best-effort cleanup; the temp install dir is still removed by t.after.
   }
+});
+
+test("restart.sh refuses a live foreign listener when the owner record is missing", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("restart.sh is POSIX-only");
+    return;
+  }
+  const probe = createServer();
+  const port = await listen(probe);
+  await new Promise((resolve) => probe.close(resolve));
+  const root = mkdtempSync(path.join(os.tmpdir(), "modeldock-restart-foreign-"));
+  const stateDir = path.join(root, ".state");
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  mkdirSync(path.join(root, "dist"), { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(path.join(root, ".env"), `MODELDOCK_PORT=${port}\n`, "utf8");
+  writeFileSync(path.join(root, "scripts", "restart.sh"), readFileSync(path.join(repoRoot, "scripts", "restart.sh")), { mode: 0o755 });
+  writeFileSync(path.join(root, "dist", "modeldock.mjs"), "process.exit(0);\n", "utf8");
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const foreign = spawn(process.execPath, ["--input-type=module", "-e", `
+import http from "node:http";
+http.createServer((req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ ok: true, marker: "foreign" }));
+}).listen(Number(process.env.MODELDOCK_PORT), "127.0.0.1");
+`], { env: { ...process.env, MODELDOCK_PORT: String(port) }, stdio: "ignore" });
+  t.after(() => foreign.kill("SIGKILL"));
+  assert.ok(await waitForHealth(port, "foreign"));
+  const child = spawn("sh", [path.join(root, "scripts", "restart.sh")], {
+    env: { ...process.env, MODELDOCK_PORT: String(port), MODELDOCK_STATE_DIR: stateDir },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => (output += chunk));
+  child.stderr.on("data", (chunk) => (output += chunk));
+  const exitCode = await new Promise((resolve) => child.on("close", resolve));
+  assert.equal(exitCode, 2, output);
+  assert.match(output, /ownership could not be verified|owner record is missing/i);
+  assert.ok(await waitForHealth(port, "foreign"), "foreign listener must survive the refused restart");
 });

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -43,7 +43,15 @@ test("serves both local MCP tools over Streamable HTTP", async (t) => {
   });
 
   const client = new Client({ name: "test-client", version: "1.0.0" });
-  await client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${server.address().port}/mcp`)));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const request = { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }) };
+  const bare = await fetch(`${base}/mcp`, request);
+  assert.equal(bare.status, 401);
+  assert.equal((await bare.json()).error.type, "caller_key_required");
+  const wrong = await fetch(`${base}/c/not-the-caller-key-but-long-enough/mcp`, request);
+  assert.equal(wrong.status, 401);
+  assert.equal((await wrong.json()).error.type, "invalid_caller_key");
+  await client.connect(new StreamableHTTPClientTransport(new URL(`${base}/c/${instance.services.callerKey}/mcp`)));
   t.after(() => client.close());
   const result = await client.listTools();
   assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ["hear", "speak", "vision_inspect", "web_search_exa"]);


### PR DESCRIPTION
## What changed

- fail closed before restart or uninstall can stop an unverified listener
- reset partial JSON image relays instead of appending a corrupt error body
- commit complete updater rollback metadata before replacing installed files
- protect the gateway MCP endpoint with the existing caller capability key
- synchronize embedded installer helpers and update direct MCP consumers
- add Windows, POSIX, updater crash, relay failure, and MCP authentication regressions

## Why

PR 16 fixed the original lifecycle and relay failures, but review found remaining crash windows, ownership gaps, partial-JSON corruption, and an unauthenticated MCP route. These changes close those paths without changing the public Responses contract.

## Validation

- `npm run build`
- `npm test` (349 passed, 2 platform skips)
- `npm run test:install` (6 passed)
- clean clone: `npm ci`, build, full tests, and installer tests; audit reported 0 vulnerabilities
- PowerShell parser check for standalone and embedded scripts
- POSIX shell syntax checks; WSL Node runtime was unavailable, while the WSL/macOS installer simulation passed
