### PR TITLE
fix: correct Xiaomi MiMo labels mislabelled as MiniMax

### DIFF
--- a/src/profiles.mjs
+++ b/src/profiles.mjs
@@ -180,11 +180,11 @@ const OPENCODE_GO_PROFILE = {
     { id: "kimi-k2.6", label: "Kimi K2.6", endpoint: "responses", supportsVision: true, visionScore: 9, visionMaxScore: 9, visionTier: "strong", quota5h: 1150, speedTier: "fast", status: "available" },
     { id: "kimi-k2.7-code", label: "Kimi K2.7 Code", endpoint: "responses", supportsVision: true, visionScore: 9, visionMaxScore: 9, visionTier: "strong", quota5h: 1350, speedTier: "fast", status: "available" },
     { id: "kimi-k3", label: "Kimi K3", endpoint: "responses", supportsVision: false, status: "available" },
-    { id: "mimo-v2.5", label: "MiniMax M2.5", endpoint: "responses", supportsVision: true, visionScore: 6, visionMaxScore: 9, visionTier: "medium", quota5h: 30100, speedTier: "medium", status: "available" },
+    { id: "mimo-v2.5", label: "MiMo V2.5", endpoint: "responses", supportsVision: true, visionScore: 6, visionMaxScore: 9, visionTier: "medium", quota5h: 30100, speedTier: "medium", status: "available" },
     { id: "mimo-v2.5-free", label: "MiMo V2.5 Free", endpoint: "responses", zen: true, supportsVision: true, visionScore: 6, visionMaxScore: 9, visionTier: "medium", quota5h: 100000, speedTier: "fast", free: true, status: "available" },
-    { id: "mimo-v2.5-pro", label: "MiniMax M2.5 Pro", endpoint: "responses", supportsVision: false, status: "available" },
-    { id: "mimo-v2-omni", label: "MiniMax M2 Omni", endpoint: "responses", supportsVision: false, status: "unavailable" },
-    { id: "mimo-v2-pro", label: "MiniMax M2 Pro", endpoint: "responses", supportsVision: false, status: "unavailable" },
+    { id: "mimo-v2.5-pro", label: "MiMo V2.5 Pro", endpoint: "responses", supportsVision: false, status: "available" },
+    { id: "mimo-v2-omni", label: "MiMo V2 Omni", endpoint: "responses", supportsVision: false, status: "unavailable" },
+    { id: "mimo-v2-pro", label: "MiMo V2 Pro", endpoint: "responses", supportsVision: false, status: "unavailable" },
     // Chat-completions dialect is not supported by the passthrough gateway yet.
     // These models stay published-unavailable so the picker never offers a model
     // that would 400. Note several of them are vision-capable (minimax-m3, qwen3.5/


### PR DESCRIPTION
Closes #18

The `mimo-*` models are **Xiaomi MiMo** (MiMo-7B Apr 2025; MiMo-V2.5 / V2.5-Pro Apr 2026, open-sourced MIT, mimo.xiaomi.com), not **MiniMax** (Shanghai MiniMax / 稀宇科技, M3 / M2.7 / M2.5 series).

Before this change `mimo-v2.5` and `minimax-m2.5` both rendered as "MiniMax M2.5" — a label collision in the catalog and the dashboard vision picker (the paid MiMo V2.5 showed up as "MiniMax M2.5", inconsistent with `mimo-v2.5-free` which was already "MiMo V2.5 Free").

Changes (labels only, no behavior change):
- `mimo-v2.5` → "MiMo V2.5"
- `mimo-v2.5-pro` → "MiMo V2.5 Pro"
- `mimo-v2-omni` → "MiMo V2 Omni"
- `mimo-v2-pro` → "MiMo V2 Pro"

The `minimax-*` entries are untouched.