### PR TITLE
fix: honour MODELDOCK_STATE_DIR in initAutostartDefault

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -28,7 +28,7 @@ import { PROVIDER_SEPARATOR, applyCustomProfile, applyOllamaProfile, bareModelId
 import { CustomEndpointError, listEndpointModels, normalizeBaseUrl, probeCustomResponses } from "./custom-endpoint.mjs";
 import { OLLAMA_DEFAULT_BASE, OllamaError, clearOllamaSnapshot, listOllamaModels, normalizeOllamaBase, ollamaSnapshotPath, probeOllamaResponses, readOllamaSnapshot, writeOllamaSnapshot } from "./ollama.mjs";
 import { recordSettingsEvent } from "./settings-events.mjs";
-import { stateFile } from "./state-dir.mjs";
+import { stateDir as resolveStateDir, stateFile } from "./state-dir.mjs";
 import staticFiles from "./static-inline.mjs";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1765,7 +1765,7 @@ export function createApp(services = createServices()) {
 // and re-enabling happens at most once per version, so the dashboard toggle
 // keeps working and nothing re-registers repeatedly. Safe to call repeatedly.
 export async function initAutostartDefault(autostart, {
-  stateDir = path.join(os.homedir(), ".modeldock"),
+  stateDir = resolveStateDir(),
   markName = "autostart-initialized",
   version = localVersion(),
 } = {}) {

--- a/test/server-api.test.mjs
+++ b/test/server-api.test.mjs
@@ -851,6 +851,30 @@ test("initAutostartDefault re-enables exactly once per new version", async (t) =
   assert.deepEqual(autostart.calls, [true, true], "re-enabling happens exactly once per version");
 });
 
+test("initAutostartDefault honours MODELDOCK_STATE_DIR", async (t) => {
+  // Every other caller in this file passes stateDir explicitly, so the default
+  // was never exercised: it resolved to the real ~/.modeldock regardless of the
+  // redirect. A spawned test gateway therefore stamped the developer's own
+  // marker, and the version recorded there made their next real start re-enable
+  // login autostart.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "modeldock-autostart-statedir-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const previous = process.env.MODELDOCK_STATE_DIR;
+  process.env.MODELDOCK_STATE_DIR = dir;
+  t.after(() => {
+    if (previous === undefined) delete process.env.MODELDOCK_STATE_DIR;
+    else process.env.MODELDOCK_STATE_DIR = previous;
+  });
+  const autostart = fakeAutostart();
+
+  assert.equal(await initAutostartDefault(autostart, { version: "1.2.3" }), true);
+  assert.equal(
+    JSON.parse(await readFile(path.join(dir, "autostart-initialized"), "utf8")).version,
+    "1.2.3",
+    "the marker lands in the redirected state dir, not the real home",
+  );
+});
+
 test("initAutostartDefault migrates a legacy timestamp marker for the new version", async (t) => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "modeldock-autostart-legacy-"));
   t.after(() => rm(dir, { recursive: true, force: true }));


### PR DESCRIPTION
`state-dir.mjs` exists so the redirect keeps a spawned test gateway's bookkeeping *"in its own throwaway root instead of littering the user's ~/.modeldock"*. `initAutostartDefault` is the one caller that still resolves its own default, so it always writes to the real home.

That marker records a version. A suite run therefore stamps the developer's own `~/.modeldock/autostart-initialized` with a test version — and on their next real gateway start the mismatch re-enables login autostart, registering a LaunchAgent / Run key they didn't ask for. I hit this on my own machine.

Every existing test passes `stateDir` explicitly, so the default was never covered. Adds a test for it.

Two follow-ups I left out to keep this focused, happy to do either if you want them:
- `test/preload-env.mjs` could set `MODELDOCK_STATE_DIR` alongside the two `*_EVENTS_FILE` redirects, closing the same gap for tests that don't set it themselves. I tried it and it shifts behaviour for the child-spawning install/restart tests, so it seemed like your call rather than mine.
- `restart.sh stops the owned listener…`, `mock install lifecycle…` and `media-store`'s TTL eviction test fail intermittently on `main` for me (same commit, one run 0 failures, next run 2). Unrelated to this change, but happy to file separately.