### PR TITLE
fix(mcp): hear is not read-only

### DIFF
--- a/src/mcp.mjs
+++ b/src/mcp.mjs
@@ -142,7 +142,9 @@ export function createMcpServer({ upstreams, acceptScopeOnly = false }) {
             language: z.string().optional().describe("Optional language hint, e.g. zh-CN, en-US. Defaults to the installed Chinese recognizer."),
             output: z.string().optional().describe("Optional absolute file path for the intermediate WAV."),
           }),
-          annotations: { readOnlyHint: true, openWorldHint: false },
+          // Not read-only: sttTranscribe transcodes the input to a WAV with
+          // `ffmpeg -y`, at `output` when the caller supplies one.
+          annotations: { readOnlyHint: false, openWorldHint: false },
         },
         async (args) => {
           try {

--- a/test/mcp-standalone.test.mjs
+++ b/test/mcp-standalone.test.mjs
@@ -105,6 +105,15 @@ test("stdio bridge lists the four tools locally without a gateway round trip", a
       false,
       "web search is read-only and must not be hidden by Codex's open-world gate",
     );
+    // hear writes: sttTranscribe transcodes the input to a WAV with `ffmpeg -y`,
+    // at the caller-supplied `output` path when one is given. A readOnlyHint of
+    // true tells a client it can run the tool without a write confirmation.
+    const hear = listed.result.tools.find((tool) => tool.name === "hear");
+    assert.equal(
+      hear.annotations?.readOnlyHint,
+      false,
+      "hear writes an intermediate WAV, so it must not be annotated read-only",
+    );
   } finally {
     await stopBridge(bridge);
     await gateway.close();


### PR DESCRIPTION
The `hear` tool is annotated `readOnlyHint: true`, but `sttTranscribe` transcodes the input to a WAV with `ffmpeg -y` — at the caller-supplied `output` path when one is given. The annotation tells an MCP client it can run the tool without a write confirmation.

One-line annotation change plus an assertion in the existing `tools/list` test, next to the `openWorldHint` one already there.

I left `ttsOutputPath` alone: `test/tts.test.mjs` pins the absolute-path behaviour as documented and intentional, so narrowing it looked like your call rather than a bug.