### PR TITLE
test: stop the media-store eviction test racing the scheduler

### DIFF
--- a/test/media-store.test.mjs
+++ b/test/media-store.test.mjs
@@ -109,13 +109,18 @@ test("evicts least recently accessed entries beyond maxEntries", () => {
 });
 
 test("evicts expired entries by lastAccessAt not createdAt", async () => {
+  // cleanup() already takes an explicit `now`, so the expiry window can be
+  // arithmetic instead of a race against the scheduler: under a loaded parallel
+  // run the second 60ms setTimeout can land past the 100ms TTL and evict the
+  // entry the test requires to survive. Only the first sleep stays real, to
+  // separate r1's lastAccessAt from its createdAt.
   const store = makeStore({ ttlMs: 100, maxEntries: 2 });
   const r1 = store.put(DATA_URL);
   const r2 = store.put(DATA_URL_OTHER);
   await new Promise((resolve) => setTimeout(resolve, 60));
   store.get(r1);
-  await new Promise((resolve) => setTimeout(resolve, 60));
-  store.cleanup();
+  const accessedAt = Date.now();
+  store.cleanup(accessedAt + 60);
   assert.ok(store.get(r1), "r1 was accessed recently so must survive");
   assert.equal(store.get(r2), undefined, "r2 expired and must be gone");
   const r3 = store.put("data:image/png;base64,EEEE");


### PR DESCRIPTION
The eviction test sleeps 60ms twice against a 100ms TTL, then calls `cleanup()` with the wall clock. The second sleep only has to overshoot by 40ms for `r1` to reach the TTL and be evicted.

Under a loaded parallel run it does. On an M-series Mac it fails roughly two runs in three of the full suite, while passing every time in isolation — which is why it reads as stable locally.

```
$ for i in 1 2 3; do node --test test/*.test.mjs | grep -c "✖ evicts expired"; done
0
2
2
```

`cleanup()` already takes an explicit `now`, so the window can be arithmetic instead of a race:

- `r1` is pinned at 60ms of its 100ms TTL — fixed, regardless of load.
- `r2`'s age becomes 60ms plus however long the first sleep really took. `setTimeout` can only overshoot, never fire early, so `r2` is always past the TTL.

The first sleep stays real, since separating `r1`'s `lastAccessAt` from its `createdAt` is the property under test.

20 consecutive full-suite runs clean after the change.