### PR TITLE
fix(native-catalog): parse the version out of the codex --version banner

### DIFF
--- a/src/native-catalog.mjs
+++ b/src/native-catalog.mjs
@@ -123,10 +123,18 @@ export function nativeModelSlugs(config) {
   return slugs;
 }
 
+// `codex --version` prints a banner - "codex-cli 0.145.0" - so the version is
+// the first dotted-numeric token, not the first token. Exported because it is
+// the only part of codexVersion() that is testable without a real binary.
+// Anything unrecognised becomes "", which callers must read as "unknown".
+export function parseCodexVersion(output) {
+  const match = /(?:^|\s)(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)(?=\s|$)/.exec(String(output ?? "").trim());
+  return match ? match[1] : "";
+}
+
 async function codexVersion() {
   try {
-    const out = await runCodex(["--version"], 5_000);
-    return String(out || "").trim().split(/\s+/)[0] || "";
+    return parseCodexVersion(await runCodex(["--version"], 5_000));
   } catch {
     return "";
   }

--- a/test/native-catalog.test.mjs
+++ b/test/native-catalog.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import os from "node:os";
 import path from "node:path";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { desktopCodexCandidates, nativeCatalogPath, nativeModelSlugs, readNativeCatalog } from "../src/native-catalog.mjs";
+import { desktopCodexCandidates, nativeCatalogPath, nativeModelSlugs, parseCodexVersion, readNativeCatalog } from "../src/native-catalog.mjs";
 
 function writeCapture(file, models) {
   writeFileSync(file, JSON.stringify({ captured_with: "0.1.0", models }), "utf8");
@@ -60,4 +60,19 @@ test("desktopCodexCandidates covers the bundled Windows and macOS CLIs", () => {
 
   const win = desktopCodexCandidates("win32");
   assert.ok(win.every((candidate) => candidate.endsWith("codex.exe")), "Windows candidates must point at codex.exe");
+});
+
+test("parseCodexVersion reads the version out of the CLI banner", () => {
+  assert.equal(parseCodexVersion("codex-cli 0.145.0"), "0.145.0");
+  assert.equal(parseCodexVersion("codex-cli 0.145.0\n"), "0.145.0");
+  assert.equal(parseCodexVersion("0.130.0"), "0.130.0", "a bare version still parses");
+  assert.equal(parseCodexVersion("codex-cli 0.148.0-alpha.9"), "0.148.0-alpha.9", "prereleases are kept whole");
+  assert.equal(parseCodexVersion("codex-cli 0.142.5 (abc1234)"), "0.142.5", "trailing build metadata is ignored");
+});
+
+test("parseCodexVersion returns empty for anything it cannot read", () => {
+  // "" means "unknown", which is a usable answer; a wrong version is not.
+  for (const input of ["", "   ", "codex-cli", "not a version", null, undefined]) {
+    assert.equal(parseCodexVersion(input), "", `expected "" for ${JSON.stringify(input)}`);
+  }
 });


### PR DESCRIPTION
`codexVersion()` takes the first whitespace-separated token of `codex --version`. That command prints a banner:

```
$ codex --version
codex-cli 0.145.0
```

So it returns `"codex-cli"` for every build, and the capture file records `"captured_with": "codex-cli"` instead of the version that produced it. Confirmed against a real `~/.modeldock/native-catalog.json`.

Nothing misbehaves today, since the field is only a stamp. Filing it anyway because it is the natural place to read the client version from and it silently answers wrong — anything built on it inherits the bug.

The fix matches the first dotted-numeric token, keeps a prerelease suffix whole so `0.148.0-alpha.9` stays distinguishable from `0.148.0`, and returns `""` when nothing is recognisable so callers can tell "unknown" from a value.

`parseCodexVersion` is exported because it is the only part of `codexVersion()` testable without a real binary. `codexVersion()` still shells out and stays internal.