### PR TITLE
fix(server): do not hang shutdown on Codex keep-alive sockets

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1808,6 +1808,10 @@ export async function startServer(config = loadConfig()) {
     url: `http://${urlHost(config.host)}:${config.port}`,
     async stop() {
       await instance.close();
+      // Codex leaves HTTP keep-alive sockets. server.close() waits for them, so
+      // SIGTERM would drop LISTEN while the process stayed alive and launchd
+      // KeepAlive would never relaunch. Destroy leftovers first.
+      server.closeAllConnections?.();
       await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
     },
   };
@@ -1855,11 +1859,22 @@ if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToP
     .map(([provider]) => provider);
   if (missingTokens.length) console.warn(`Tokens missing for provider(s): ${missingTokens.join(", ")}; the dashboard is available but those upstream calls will return 503.`);
 
-  const shutdown = async () => {
+  const shutdown = async (signal) => {
+    console.error(`[modeldock] shutting down on ${signal}`);
     clearOwnerFile(instance.services.config.port);
-    await instance.stop();
+    const force = setTimeout(() => {
+      console.error("[modeldock] shutdown timed out; exiting");
+      process.exit(0);
+    }, 2000);
+    force.unref();
+    try {
+      await instance.stop();
+    } catch (error) {
+      console.error(`[modeldock] shutdown error: ${error.message}`);
+    }
+    clearTimeout(force);
     process.exit(0);
   };
-  process.once("SIGINT", shutdown);
-  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", () => shutdown("SIGINT"));
+  process.once("SIGTERM", () => shutdown("SIGTERM"));
 }

--- a/test/server-api.test.mjs
+++ b/test/server-api.test.mjs
@@ -820,6 +820,31 @@ test("WebSocket upgrades are declined with 426 so Codex falls back to HTTP", asy
   assert.equal(health.status, 200);
 });
 
+test("stop() returns while an idle client connection is still open", async (t) => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "modeldock-stop-hang-"));
+  const instance = await startServer({
+    ...baseConfig(),
+    port: 0,
+    autostartDefault: false,
+    codexCatalogFile: path.join(dir, "codex-model-catalog.json"),
+    nativeCatalogFile: path.join(dir, "native-catalog.json"),
+  });
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const port = instance.server.address().port;
+  const socket = net.connect(port, "127.0.0.1");
+  t.after(() => socket.destroy());
+  await new Promise((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+  const started = Date.now();
+  await Promise.race([
+    instance.stop(),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("stop() hung on an open connection")), 2000)),
+  ]);
+  assert.ok(Date.now() - started < 2000, "SIGTERM/stop must not wait forever for Codex keep-alives");
+});
+
 function fakeAutostart({ enabled = false, fail = false } = {}) {
   const calls = [];
   return {


### PR DESCRIPTION
## What was going wrong

After SIGTERM, Model Dock stopped listening but the process stayed alive. A KeepAlive supervisor (launchd, systemd) still saw a running pid, so it did not start a new listener. Codex then got connection refused / “high demand” even though the job looked healthy.

## Why this exists

Node `server.close()` waits for every existing HTTP connection to end. Codex keeps keep-alive sockets open against the local gate. SIGTERM therefore drops the listen socket (new requests fail) while old sockets hold the process open.

This is the Node HTTP contract meeting a long-lived Codex client. It is not a crash in request handling.

## Why it is worth fixing

Any SIGTERM can trigger it: a manual restart, logout, or a supervisor recycle. A stuck local gate looks like an upstream outage and takes the whole Codex session with it.

## Why this approach

Keep-alives are idle sockets, not in-flight work, so they should not block process death. Destroy them with `closeAllConnections()` before `close()`, and cap CLI shutdown at 2s so the process always exits even if something else hangs.