### PR TITLE
fix(router): keep agentic turns on the text model

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -14,7 +14,12 @@ export function isAssistantMarker(item) {
   if (item.role === "assistant") return true;
   return item.type === "function_call"
     || item.type === "custom_tool_call"
-    || item.type === "reasoning";
+    || item.type === "reasoning"
+    // Compact replaces the assistant/tool loop with a checkpoint item. Codex
+    // then keeps older user messages (screenshots included) in the replayed
+    // history. If compaction is not a boundary, lastMarker stays -1 and those
+    // leftover images look like the current turn forever.
+    || item.type === "compaction";
 }
 
 function currentTurnItems(input) {
@@ -32,6 +37,22 @@ function parts(item) {
 
 function hasImage(items) {
   return items.some((item) => parts(item).some((part) => part?.type === "input_image" && typeof part.image_url === "string"));
+}
+
+// An agentic Responses payload already has tool/reasoning items. Escalating that
+// whole history onto the vision model is not how "see" works: pasted-image chat
+// can swap models, but a coding loop must stay on the text model and inspect
+// via vision_inspect. Presence of agent items is the test, not payload length.
+const AGENTIC_ITEM_TYPES = new Set([
+  "function_call",
+  "function_call_output",
+  "custom_tool_call",
+  "custom_tool_call_output",
+  "reasoning",
+]);
+
+export function isAgenticHistory(input) {
+  return inputItems(input).some((item) => AGENTIC_ITEM_TYPES.has(item?.type));
 }
 
 function continuationCallIds(items) {
@@ -101,7 +122,7 @@ export function routeResponsesRequest(source, { mainModel, visionModel, affinity
   if (source?.model === visionModel && source?.model !== mainModel) {
     return { model: visionModel, reason: "vision_model_requested", directVision: true };
   }
-  if (hasImage(current)) {
+  if (hasImage(current) && !isAgenticHistory(source?.input)) {
     if (mainModelSupportsVision) {
       return { model: mainModel, reason: "current_turn_image", directVision: true };
     }

--- a/test/router.test.mjs
+++ b/test/router.test.mjs
@@ -65,7 +65,36 @@ test("a tool-call-only assistant turn ends the turn; a stale image behind it doe
   assert.equal(route.model, "deepseek-v4-flash");
 });
 
-test("a genuinely new image after a tool-call turn still routes to vision", () => {
+test("a compaction item ends the turn; a stale image behind it does not re-trigger vision", () => {
+  const route = routeResponsesRequest({
+    model: "deepseek-v4-flash",
+    input: [
+      { role: "user", content: [{ type: "input_text", text: "look" }, { type: "input_image", image_url: "data:image/jpeg;base64,AA==" }] },
+      { type: "compaction", id: "cmp_1", encrypted_content: "kcr1:e30=" },
+      { role: "user", content: [{ type: "input_text", text: "continue" }] },
+    ],
+  }, { mainModel: "deepseek-v4-flash", visionModel: "gpt-5.6-luna", knownModels: new Set(["deepseek-v4-flash"]) });
+  assert.notEqual(route.reason, "current_turn_image", "a stale image behind compaction must not re-trigger vision");
+  assert.equal(route.model, "deepseek-v4-flash");
+});
+
+test("a genuinely new image after compaction still routes to vision", () => {
+  const route = routeResponsesRequest({
+    model: "deepseek-v4-flash",
+    input: [
+      { role: "user", content: [{ type: "input_text", text: "start" }] },
+      { type: "compaction", id: "cmp_1", encrypted_content: "kcr1:e30=" },
+      { role: "user", content: [{ type: "input_image", image_url: "data:image/png;base64,BB==" }] },
+    ],
+  }, { mainModel: "deepseek-v4-flash", visionModel: "gpt-5.6-luna", knownModels: new Set(["deepseek-v4-flash"]) });
+  assert.equal(route.reason, "current_turn_image");
+  assert.equal(route.model, "gpt-5.6-luna");
+});
+
+test("a new image during an agentic tool loop stays on the text model", () => {
+  // Pasted-image escalation is for ordinary chat. Once the payload already has
+  // tool/reasoning items, the coding model stays in charge and inspects via
+  // vision_inspect instead of shipping the whole history to the vision model.
   const route = routeResponsesRequest({
     model: "deepseek-v4-flash",
     input: [
@@ -75,8 +104,9 @@ test("a genuinely new image after a tool-call turn still routes to vision", () =
       { role: "user", content: [{ type: "input_image", image_url: "data:image/png;base64,BB==" }] },
     ],
   }, { mainModel: "deepseek-v4-flash", visionModel: "gpt-5.6-luna", knownModels: new Set(["deepseek-v4-flash"]) });
-  assert.equal(route.reason, "current_turn_image");
-  assert.equal(route.model, "gpt-5.6-luna");
+  assert.notEqual(route.reason, "current_turn_image");
+  assert.equal(route.model, "deepseek-v4-flash");
+  assert.equal(route.directVision, false);
 });
 
 test("does not treat Codex developer instructions about image support as user visual intent", () => {


### PR DESCRIPTION
## What was going wrong

A pasted screenshot is supposed to escalate **that chat turn** to the vision model. Two other shapes were treated the same way, so the **entire** Responses request (tools, reasoning, history) was sent to vision:

1. After compact, Codex replays older user messages (screenshots included) plus a `compaction` item. Compaction was not a turn boundary, so `lastMarker` stayed `-1` and every later text follow-up still looked visual.
2. In a coding loop the payload already has `function_call` / `reasoning` items. A new screenshot still swapped that whole agent history onto the vision model.

Vision models on OpenCode Go cannot run that wire shape, so the turn 400s.

## Why this exists

The router asked one question: “does the current turn contain an image?” Then it forwarded the whole request. That is the right heuristic for ordinary pasted-image chat. It is the wrong heuristic once history includes compact markers or an agent loop. The gateway never distinguished those payloads.

## Why it is worth fixing

Without this, compact follow-ups and agent turns with a screenshot leave the text model the user picked. “See this picture” is a real product feature. Hijacking the coding model is not the same as seeing. `vision_inspect` still exists for agent turns that need pixels.

## Why this approach

Keep current-turn image escalation for chat that is **not** already agentic (no tool/reasoning items in `input`). Treat `compaction` as a turn boundary so leftover screenshots do not re-trigger vision. A **new** image after compact still escalates.

The test is “is this an agent payload?”, not payload length. An 8-item or 40-item cutoff would be an invented definition of a thread; Codex already marks agent work with tool/reasoning items.