### PR TITLE
fix(gateway): keep compact summarize on the main text model

### DIFF
--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -2397,14 +2397,18 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
   const requestedModel = normalizeLegacySlug(typeof payload.model === "string" ? payload.model : "", knownModels);
   if (requestedModel !== payload.model && requestedModel) payload = { ...payload, model: requestedModel };
   const mainModel = mainModelFor(services, sessionId);
-  const visionModel = services.visionModel || config.visionModel;
-  const route = routeGatewayRequest(payload, {
-    mainModel,
-    visionModel,
-    affinity: routeAffinity,
-    knownModels,
-    mainModelSupportsVision: Boolean(modelEntryFor(config, mainModel)?.supportsVision),
-  });
+  // Compact is a text handoff for the coding model. Vision escalation is for
+  // pasted-image chat turns, not for summarizing a tool/reasoning history.
+  const compactModel = (
+    requestedModel
+    && knownModels?.has(requestedModel)
+    && !modelEntryFor(config, requestedModel)?.supportsVision
+  ) ? requestedModel : mainModel;
+  const route = {
+    model: compactModel,
+    reason: "compact_summarize",
+    directVision: false,
+  };
   recordDerivedFallback(services, sessionId, route);
   // Custom/ollama backends must see the same adapted shape on the compact path
   // as on the main relay path: Codex's mid-history system/developer items
@@ -2431,7 +2435,7 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
         rewriteHistoricalImages(
           normalizedInput,
           mediaStore,
-          { preserveCurrentImages: route.directVision },
+          { preserveCurrentImages: false },
         ),
         modelEntryFor(config, route.model)?.imageUrlShape,
       ),

--- a/test/gateway.test.mjs
+++ b/test/gateway.test.mjs
@@ -2497,6 +2497,52 @@ test("relayResponses intercepts a v2 compact request and synthesizes a compactio
   }
 });
 
+test("relayCompaction keeps the main model when recent history still carries an image", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, options) => {
+    calls.push(JSON.parse(options.body));
+    return summaryResponse("compact ok");
+  };
+  try {
+    const result = await relayCompaction(
+      {
+        model: "deepseek-v4-flash@opencode-go",
+        stream: false,
+        input: [
+          { type: "message", role: "user", content: [
+            { type: "input_text", text: "see screenshot" },
+            { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+          ] },
+          { type: "compaction_trigger" },
+        ],
+      },
+      res,
+      {
+        ...compactServices(),
+        knownModels: new Set(["deepseek-v4-flash@opencode-go", "gpt-5.6-luna@opencode-go"]),
+        mainModel: "deepseek-v4-flash@opencode-go",
+        visionModel: "gpt-5.6-luna@opencode-go",
+      },
+      {},
+      true,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.route.model, "deepseek-v4-flash@opencode-go", "compact must not escalate to the vision model");
+    assert.equal(result.route.reason, "compact_summarize");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].model, "deepseek-v4-flash", "the upstream summarize call stays on the main model");
+    assert.ok(
+      calls[0].input.every((item) => !item.content?.some?.((part) => part.type === "input_image")),
+      "compact summarize rewrites images to text refs instead of shipping pixels",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("relayCompaction applies the Pro duplicate-call repair before summarizing", async () => {
   const sink = collectStream();
   const res = responseStub(sink);


### PR DESCRIPTION
## What was going wrong

Codex remote compact (`compact_v2` / `compact_v1`) 400s on OpenCode Go: the summarize call was sent to the vision model with the full history (images, tools, reasoning). Codex reports a failed remote compact and the thread cannot continue.

## Why this exists

Compact went through the same `routeGatewayRequest` path as a user turn. That path escalates to vision when it thinks the current turn has an image. Compact is a summarize of the **whole** history, so leftover screenshots (or a confused current-turn scan) make the checkpoint look visual. Compact was never a “look at this picture” turn; it is a text handoff so the session can keep going.

## Why it is worth fixing

Long Codex sessions depend on remote compact. A 400 here leaves the thread stuck until the user starts over. The vision model is the wrong worker for a checkpoint summary.

## Why this approach

Always run the summarize call on the main text model (`compact_summarize`), never the vision model. Rewrite images to refs so pixels are not part of the handoff. Local/CPU compact paths are unchanged.

This is independent of PR #28: even with better user-turn routing, compact should not share that router. Compact is not a user turn.