### PR TITLE
fix(gateway): normalize MCP function tool schemas before upstream relay

### DIFF
--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -1191,6 +1191,19 @@ export function rewriteHistoricalImages(input, mediaStore, { preserveCurrentImag
   });
 }
 
+// OpenCode Go rejects function tools whose parameters schema is missing or not
+// type:"object". Codex MCP children often carry inputSchema instead of parameters.
+function normalizeFunctionTool(tool) {
+  if (!tool || typeof tool !== "object") return tool;
+  const parameters = tool.parameters ?? tool.inputSchema;
+  const normalized = parameters && typeof parameters === "object" && parameters.type === "object"
+    ? parameters
+    : { type: "object", properties: {}, additionalProperties: false };
+  const next = { ...tool, type: "function", parameters: normalized };
+  delete next.inputSchema;
+  return next;
+}
+
 // Tool policy: keep standard function/custom tools, flatten MCP namespaces so
 // text models see plain functions, and strip hosted schemas plus tools the model
 // cannot use. Returns the filtered list and a report of what was removed.
@@ -1220,7 +1233,7 @@ export function applyToolPolicy(tools, { hiddenToolNames = TEXT_MODEL_HIDDEN_TOO
           continue;
         }
         stripped.namespaceChildren += 1;
-        out.push({ ...structuredClone(child), type: "function", name: `${tool.name}__${child.name}` });
+        out.push(normalizeFunctionTool({ ...structuredClone(child), type: "function", name: `${tool.name}__${child.name}` }));
       }
       continue;
     }
@@ -1238,7 +1251,7 @@ export function applyToolPolicy(tools, { hiddenToolNames = TEXT_MODEL_HIDDEN_TOO
       stripped.allowlist += 1;
       continue;
     }
-    out.push(structuredClone(tool));
+    out.push(tool.type === "function" ? normalizeFunctionTool(structuredClone(tool)) : structuredClone(tool));
   }
   return { tools: out, stripped };
 }

--- a/test/gateway.test.mjs
+++ b/test/gateway.test.mjs
@@ -812,8 +812,25 @@ test("applyToolPolicy flattens MCP namespaces into qualified functions", () => {
   assert.equal(kept.length, 1);
   assert.equal(kept[0].type, "function");
   assert.equal(kept[0].name, "namespace:mcp__test__hello");
+  assert.deepEqual(kept[0].parameters, { type: "object", properties: {}, additionalProperties: false });
   assert.equal(stripped.namespaceChildren, 1);
   assert.equal(stripped.hidden, 1);
+});
+
+test("applyToolPolicy maps MCP inputSchema onto a type:object parameters schema", () => {
+  const tools = [{
+    type: "namespace",
+    name: "mcp__example",
+    tools: [{
+      type: "function",
+      name: "lookup",
+      inputSchema: { type: "object", properties: { q: { type: "string" } } },
+    }],
+  }];
+  const { tools: kept } = applyToolPolicy(tools);
+  assert.equal(kept[0].name, "mcp__example__lookup");
+  assert.deepEqual(kept[0].parameters, { type: "object", properties: { q: { type: "string" } } });
+  assert.equal(kept[0].inputSchema, undefined);
 });
 
 test("applyToolPolicy whitelist keeps only allowed tools and counts trims", () => {


### PR DESCRIPTION
## What was going wrong

When Codex attaches MCP servers, a Responses turn against OpenCode Go can 400 before the model runs: `tools[N].function.parameters is invalid`. The whole turn dies. Catalog tools such as `vision_inspect` never reach the model, even though the user asked for them.

## Why this exists

Two dialects meet at the gateway and nobody translated them.

- Codex / MCP advertise tools as **namespace children**, often with MCP `inputSchema`, or with `parameters: {}` / a missing schema.
- OpenAI function-calling (what OpenCode Go validates) wants `function.parameters` as a JSON Schema object with `"type": "object"`. Empty `{}` is not that. `inputSchema` is the wrong field name.

Model Dock already flattens nested MCP namespaces onto the tool list. Flattening copied the children as-is, so the illegal envelope was forwarded. This is a schema mismatch, not a missing tool implementation and not “the model refused to call MCP.”

## Why it is worth fixing

The advertised MCP surface is how a text model is supposed to see, search, and remember through this gateway. If Go rejects the envelope, those tools do not exist in practice. Every Codex session that has MCP servers attached can hit this; it is not an edge-case polish.

## Why this approach

The gateway already rewrites the tool list (flatten). Schema normalize belongs in that same rewrite, not in Codex and not by executing tools server-side.

When flattening MCP namespaces (and when forwarding `type: "function"` tools): copy `inputSchema` onto `parameters` if needed; if the result is not `type: "object"`, use a valid empty object schema (`{ "type": "object", "properties": {} }`). That is the OpenAI-legal stand-in for “no args” / unknown shape. We do not invent per-tool schemas.

The gateway still only **advertises** the tools. Execution stays with Codex / the MCP client, which is the thin-gateway contract.