### PR TITLE
feat(catalog): publish ultra effort on Codex 0.144+ captures

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -130,31 +130,60 @@ export function catalogFor(config) {
 export function mergeNativeCatalog(catalog, config) {
   const native = readNativeCatalog(config);
   if (!native?.models?.length) return catalog;
+  const allowed = allowedEffortsFor(native.captured_with);
   const published = new Set((catalog.models || []).map((entry) => entry?.slug));
   const extra = native.models.filter((model) => (
     model?.slug
     && model.visibility === "list"
     && !published.has(model.slug)
-  )).map((model) => nativeEntryForCatalog(sanitizeNativeReasoningLevels(model)));
+  )).map((model) => nativeEntryForCatalog(sanitizeNativeReasoningLevels(model, allowed)));
   if (!extra.length) return catalog;
   return { ...catalog, models: [...(catalog.models || []), ...extra] };
 }
 
-// The Codex CLI (0.130.x) rejects reasoning efforts above `xhigh` when parsing
-// model_catalog_json, but newer bundled native catalogs advertise `max` and
-// `ultra`. Filter merged native entries down to the enum every published Codex
-// build accepts so both the App picker and CLI tooling parse the file.
-const ALLOWED_REASONING_LEVELS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+// Codex releases before 0.138.0 parse reasoning_effort as a CLOSED serde enum
+// whose variants stop at `xhigh`. A single `max` anywhere in model_catalog_json
+// makes those builds exit 1 and publish NO models. 0.138.0 switched to an open
+// enum that accepts `max`. Bundled native catalogs started advertising `ultra`
+// around 0.144/0.145; gate it separately so 0.138-0.143 clients keep `max`
+// without a picker rung older stacks may still reject upstream.
+const BASE_REASONING_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"];
+const MAX_EFFORT_MIN_VERSION = "0.138.0";
+const ULTRA_EFFORT_MIN_VERSION = "0.144.0";
 
-function sanitizeNativeReasoningLevels(model) {
+export function allowedEffortsFor(codexVersion) {
+  const levels = new Set(BASE_REASONING_LEVELS);
+  if (versionAtLeast(codexVersion, MAX_EFFORT_MIN_VERSION)) levels.add("max");
+  if (versionAtLeast(codexVersion, ULTRA_EFFORT_MIN_VERSION)) levels.add("ultra");
+  return levels;
+}
+
+function versionAtLeast(version, minimum) {
+  const parse = (value) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)(-.*)?$/.exec(String(value ?? "").trim());
+    return match && {
+      parts: [Number(match[1]), Number(match[2]), Number(match[3])],
+      prerelease: Boolean(match[4]),
+    };
+  };
+  const actual = parse(version);
+  const floor = parse(minimum);
+  if (!actual || !floor) return false;
+  for (let i = 0; i < 3; i += 1) {
+    if (actual.parts[i] !== floor.parts[i]) return actual.parts[i] > floor.parts[i];
+  }
+  return !actual.prerelease;
+}
+
+function sanitizeNativeReasoningLevels(model, allowed = allowedEffortsFor(null)) {
   if (!model || typeof model !== "object") return model;
   const levels = Array.isArray(model.supported_reasoning_levels)
-    ? model.supported_reasoning_levels.filter((level) => ALLOWED_REASONING_LEVELS.has(level?.effort))
+    ? model.supported_reasoning_levels.filter((level) => allowed.has(level?.effort))
     : model.supported_reasoning_levels;
-  const defaultLevel = ALLOWED_REASONING_LEVELS.has(model.default_reasoning_level)
+  const defaultLevel = allowed.has(model.default_reasoning_level)
     ? model.default_reasoning_level
     : Array.isArray(levels) && levels.length > 0
-      ? levels[0].effort
+      ? levels[levels.length - 1].effort
       : "medium";
   return {
     ...model,

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import os from "node:os";
 import path from "node:path";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { baseInstructionsFor, catalogFor, enabledProvidersFor, mergeNativeCatalog } from "../src/catalog.mjs";
+import { allowedEffortsFor, baseInstructionsFor, catalogFor, enabledProvidersFor, mergeNativeCatalog } from "../src/catalog.mjs";
 import { OPENCODE_GO_PROFILE } from "../src/profiles.mjs";
 import { isNativeModel } from "../src/gateway.mjs";
 
@@ -222,11 +222,11 @@ test("catalogFor publishes the free models alongside the paid ones", () => {
   assert.ok(slugs.includes("mimo-v2.5-free@opencode-go"));
 });
 
-test("mergeNativeCatalog caps native reasoning levels to the published enum", () => {
+test("mergeNativeCatalog caps native reasoning levels for an old Codex capture", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-native-test-"));
   const file = path.join(dir, "native-catalog.json");
   writeFileSync(file, JSON.stringify({
-    captured_with: "0.1.0",
+    captured_with: "0.130.0",
     models: [{
       slug: "gpt-5.6-sol",
       display_name: "GPT-5.6-Sol",
@@ -248,13 +248,92 @@ test("mergeNativeCatalog caps native reasoning levels to the published enum", ()
     assert.deepEqual(
       entry.supported_reasoning_levels.map((level) => level.effort),
       ["low", "high"],
-      "max/ultra are filtered to the enum the installed CLI accepts",
+      "pre-0.138 captures withhold max and ultra so the catalog stays parseable",
     );
-    assert.equal(entry.default_reasoning_level, "low", "default clamps to an allowed effort");
+    assert.equal(entry.default_reasoning_level, "high", "default clamps to the top surviving rung");
     assert.equal(entry.supports_reasoning_summaries, true, "required field is defaulted for older CLI parsers");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("mergeNativeCatalog keeps max but withholds ultra on a 0.138-0.143 capture", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-native-test-"));
+  const file = path.join(dir, "native-catalog.json");
+  writeFileSync(file, JSON.stringify({
+    captured_with: "0.140.0",
+    models: [{
+      slug: "gpt-5.6-sol",
+      display_name: "GPT-5.6-Sol",
+      visibility: "list",
+      priority: 1,
+      default_reasoning_level: "max",
+      supported_reasoning_levels: [
+        { effort: "low", description: "Low" },
+        { effort: "high", description: "High" },
+        { effort: "max", description: "Max" },
+        { effort: "ultra", description: "Ultra" },
+      ],
+    }],
+  }), "utf8");
+  try {
+    const entry = mergeNativeCatalog(catalogFor(configStub()), { ...configStub(), nativeCatalogFile: file })
+      .models.find((model) => model.slug === "gpt-5.6-sol");
+    assert.ok(entry, "native entry is published");
+    assert.deepEqual(
+      entry.supported_reasoning_levels.map((level) => level.effort),
+      ["low", "high", "max"],
+      "0.138+ keeps max while ultra waits for 0.144",
+    );
+    assert.equal(entry.default_reasoning_level, "max");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("mergeNativeCatalog publishes native max and ultra on a current capture", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "modeldock-native-test-"));
+  const file = path.join(dir, "native-catalog.json");
+  writeFileSync(file, JSON.stringify({
+    captured_with: "0.145.0",
+    models: [{
+      slug: "gpt-5.6-sol",
+      display_name: "GPT-5.6-Sol",
+      visibility: "list",
+      priority: 1,
+      default_reasoning_level: "max",
+      supported_reasoning_levels: [
+        { effort: "low", description: "Low" },
+        { effort: "high", description: "High" },
+        { effort: "max", description: "Max" },
+        { effort: "ultra", description: "Ultra" },
+      ],
+    }],
+  }), "utf8");
+  try {
+    const entry = mergeNativeCatalog(catalogFor(configStub()), { ...configStub(), nativeCatalogFile: file })
+      .models.find((model) => model.slug === "gpt-5.6-sol");
+    assert.ok(entry, "native entry is published");
+    assert.deepEqual(
+      entry.supported_reasoning_levels.map((level) => level.effort),
+      ["low", "high", "max", "ultra"],
+      "current captures publish the full native ladder",
+    );
+    assert.equal(entry.default_reasoning_level, "max");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("allowedEffortsFor gates max at 0.138 and ultra at 0.144", () => {
+  assert.ok(!allowedEffortsFor("0.137.9").has("max"));
+  assert.ok(!allowedEffortsFor("0.137.9").has("ultra"));
+  assert.ok(!allowedEffortsFor("0.138.0-alpha.1").has("max"), "a prerelease sorts below its release");
+  assert.ok(allowedEffortsFor("0.138.0").has("max"));
+  assert.ok(!allowedEffortsFor("0.138.0").has("ultra"));
+  assert.ok(!allowedEffortsFor("0.143.9").has("ultra"));
+  assert.ok(allowedEffortsFor("0.144.0").has("ultra"));
+  assert.ok(allowedEffortsFor("0.145.0").has("ultra"));
 });
 
 test("catalogFor groups models by provider label with sequential priorities", () => {


### PR DESCRIPTION
## Summary

Native GPT models (e.g. `gpt-5.6-sol`) advertise an `ultra` reasoning rung in bundled Codex catalogs from ~0.144 onward, but ModelDock was filtering it out at every capture version. This publishes `ultra` only when backward-compatible.

## Backward compatibility

| Codex capture (`captured_with`) | `max` | `ultra` |
|---|---|---|
| < 0.138 | withheld | withheld |
| 0.138 – 0.143 | published | withheld |
| >= 0.144 | published | published |

- Pre-0.138 Codex parses `model_catalog_json` with a closed enum ending at `xhigh`; a single `max` anywhere makes the client exit 1 and publish no models.
- 0.138+ accepts `max` via an open enum.
- `ultra` is gated separately at 0.144 to match when bundled native catalogs started advertising it and to avoid picker rungs on 0.138–0.143 stacks that may still reject it upstream.

Curated/routed models are unchanged — only native merge entries that already carry `ultra` can publish it.

## Verification

- `node --test test/catalog.test.mjs` — version-gated ladder tests for old, mid, and current captures
- Live (local): catalog + `codex exec -m gpt-5.6-sol` with `model_reasoning_effort="ultra"` through ModelDock gateway returns 200 and `"effort":"ultra"` in rollout

## Scope

Two files only: `src/catalog.mjs`, `test/catalog.test.mjs`. No gateway, auth, or private deployment changes.