### PR TITLE
Fix xAI hosted web search options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modeldock-opencode-go-gate",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modeldock-opencode-go-gate",
-      "version": "0.3.27",
+      "version": "0.3.28",
       "dependencies": {
         "@modelcontextprotocol/express": "2.0.0",
         "@modelcontextprotocol/node": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modeldock-opencode-go-gate",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "private": true,
   "type": "module",
   "description": "Give DeepSeek eyes, ears, a voice, a web connection, and a memory inside Codex - a thin local Responses bridge for OpenCode Go and DeepSeek official, with native GPT passthrough and live token, latency, and trace observability.",

--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -973,14 +973,25 @@ export function normalizeXaiInput(input) {
 }
 
 // Codex uses this OpenAI-native flag to grant its own backend web access. xAI
-// does not implement the field and rejects the whole Responses request when it
-// appears, even for a simple text turn. Its supported web_search/x_search tools
-// are handled by the xAI tool policy instead, so remove only this incompatible
-// transport hint on the xAI leg.
+// does not implement it and rejects the whole Responses request when it appears
+// either at the payload top level or on a hosted-tool descriptor. Its supported
+// web_search/x_search tools are handled by the xAI tool policy instead, so
+// remove only this incompatible transport option on the xAI leg. Do not recurse
+// into a function's parameters: a user tool can legitimately have a parameter
+// with this name.
 export function normalizeXaiPayload(payload) {
-  if (!payload || typeof payload !== "object" || !("external_web_access" in payload)) return payload;
-  const { external_web_access: _externalWebAccess, ...normalized } = payload;
-  return normalized;
+  if (!payload || typeof payload !== "object") return payload;
+  const hasPayloadExternalWebAccess = Object.prototype.hasOwnProperty.call(payload, "external_web_access");
+  const { external_web_access: _externalWebAccess, tools, ...normalized } = payload;
+  if (!Array.isArray(tools)) return hasPayloadExternalWebAccess ? normalized : payload;
+  let changed = hasPayloadExternalWebAccess;
+  const xaiTools = tools.map((tool) => {
+    if (!tool || typeof tool !== "object" || !Object.prototype.hasOwnProperty.call(tool, "external_web_access")) return tool;
+    changed = true;
+    const { external_web_access: _toolExternalWebAccess, ...cleanTool } = tool;
+    return cleanTool;
+  });
+  return changed ? { ...normalized, tools: xaiTools } : payload;
 }
 
 // llama.cpp's /v1/responses parses function_call.arguments with a strict JSON
@@ -3291,6 +3302,10 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
   if (trimLocalTools) {
     normalizedPayload.instructions = stripLocalInstructions(normalizedPayload.instructions);
   }
+  // applyToolPolicy can preserve hosted tool descriptors verbatim. Normalize
+  // again after that policy so Codex's web_search { external_web_access: true }
+  // option never reaches xAI on the final wire.
+  if (routedProvider === "xai") normalizedPayload = normalizeXaiPayload(normalizedPayload);
 
   const target = upstreamTargetFor(config, normalizedPayload.model);
   // The upstream sees the bare model id; the route model (possibly owner-suffixed)

--- a/test/xai-wire.test.mjs
+++ b/test/xai-wire.test.mjs
@@ -33,9 +33,38 @@ function codexTools() {
       name: "computer",
       tools: [{ type: "function", name: "click", description: "click a point", parameters: { type: "object", properties: { x: { type: "number" }, y: { type: "number" } }, required: ["x", "y"] } }],
     },
-    { type: "web_search" },
+    // Codex currently attaches its OpenAI-only hosted-web option here. xAI
+    // supports the tool itself but rejects this descriptor field.
+    { type: "web_search", external_web_access: true },
     { type: "tool_search" },
   ];
+}
+
+// This envelope mirrors the failed Codex Desktop request captured from the live
+// gateway: streamed, four message items, the normal Responses controls, and a
+// hosted web_search descriptor whose OpenAI-only option xAI rejects.
+function capturedCodexStreamingRequest() {
+  return {
+    model: "grok-4.6@xai",
+    instructions: "You are a coding agent. Use tools when useful and reply concisely.",
+    input: [
+      { type: "message", role: "developer", content: [{ type: "input_text", text: "Follow the workspace rules." }] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "Inspect the current project." }] },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "I will inspect it." }] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "What model are you?" }] },
+    ],
+    tools: codexTools(),
+    tool_choice: "auto",
+    parallel_tool_calls: true,
+    reasoning: { effort: "high", summary: "auto" },
+    store: false,
+    stream: true,
+    stream_options: { include_usage: true },
+    include: ["reasoning.encrypted_content"],
+    prompt_cache_key: "codex-streaming-fixture",
+    text: { format: { type: "text" } },
+    external_web_access: true,
+  };
 }
 
 const answer = (text) => ({
@@ -65,7 +94,7 @@ function fakeXai(queue) {
     for await (const chunk of req) chunks.push(chunk);
     const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
     seen.push(body);
-    if (body.external_web_access !== undefined) {
+    if (body.external_web_access !== undefined || (body.tools || []).some((tool) => tool?.external_web_access !== undefined)) {
       res.writeHead(400, { "content-type": "application/json" });
       res.end(JSON.stringify({ error: "Argument not supported: external_web_access" }));
       return;
@@ -76,8 +105,14 @@ function fakeXai(queue) {
       res.end(JSON.stringify({ error: `Failed to deserialize the JSON body into the target type: tools[].type: unknown variant \`${bad.type}\`` }));
       return;
     }
+    const response = queue.shift() || answer("ok");
+    if (body.stream) {
+      res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+      res.end(`data: ${JSON.stringify({ type: "response.completed", response })}\n\ndata: [DONE]\n\n`);
+      return;
+    }
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify(queue.shift() || answer("ok")));
+    res.end(JSON.stringify(response));
   });
   return { server, seen };
 }
@@ -172,6 +207,7 @@ test("a Grok tool round trip bridges Codex namespace and freeform patch tools", 
     // Grok runs this one itself; stripping it made the gate pay Exa to redo a
     // search the subscription already covers.
     assert.ok(types.includes("web_search"), `turn ${index + 1}: hosted search is left for Grok`);
+    assert.equal((body.tools || []).some((tool) => tool?.external_web_access !== undefined), false, `turn ${index + 1}: xAI receives no OpenAI-only hosted-web option`);
     // tool_search is answered by this gate, not by xAI.
     assert.equal(types.includes("tool_search"), false, `turn ${index + 1}: tool_search is ours`);
     assert.equal(body.model, "grok-4.5", "the upstream sees the bare id, not the routing suffix");
@@ -228,6 +264,27 @@ test("a Grok request drops Codex's OpenAI-only external web access flag", async 
   assert.equal(response.status, 200, "xAI rejects the unfiltered flag with HTTP 400");
   assert.equal(seen.length, 1);
   assert.equal(seen[0].external_web_access, undefined, "the xAI wire contains no OpenAI-only transport flag");
+});
+
+test("a captured Codex streaming envelope keeps xAI web search but removes its OpenAI-only option", async (t) => {
+  const { base, seen } = await startGrokApp(t, [answer("I am Grok.")]);
+  const response = await fetch(`${base}/v1/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(capturedCodexStreamingRequest()),
+  });
+
+  assert.equal(response.status, 200, "the exact streamed Codex-shaped request reaches xAI");
+  assert.match(await response.text(), /response\.completed/, "the streamed response reaches Codex");
+  assert.equal(seen.length, 1);
+  const outbound = seen[0];
+  assert.equal(outbound.model, "grok-4.6");
+  assert.equal(outbound.stream, true);
+  assert.equal(outbound.input.length, 4, "the complete message envelope survives");
+  assert.deepEqual(outbound.include, ["reasoning.encrypted_content"]);
+  assert.equal(outbound.external_web_access, undefined, "the top-level OpenAI-only option is removed");
+  assert.equal((outbound.tools || []).some((tool) => tool?.external_web_access !== undefined), false, "the nested OpenAI-only option is removed");
+  assert.ok((outbound.tools || []).some((tool) => tool?.type === "web_search"), "Grok keeps its native web search capability");
 });
 
 test("a visual Grok compaction keeps image evidence and returns a Codex handoff", async (t) => {


### PR DESCRIPTION
Removes the OpenAI-only external_web_access field from retained xAI hosted-tool descriptors while preserving Grok web_search. Adds a captured Codex streaming-envelope regression and bumps the release to 0.3.28.