### PR TITLE
Fix compact routing and agent_message replay for routed providers

### DIFF
--- a/src/gateway.mjs
+++ b/src/gateway.mjs
@@ -13,7 +13,7 @@ import { CURRENT_TURN_MARKER, RouteAffinity, currentTurnHasImage, currentTurnSta
 import { extractResponseUsage } from "./metrics.mjs";
 import { stateDir } from "./state-dir.mjs";
 import { customEndpointFor } from "./custom-endpoints.mjs";
-import { historicalImageSpawnHint, hasOpaqueCollaboration, promoteCollaborationNewTask } from "./subagent-guidance.mjs";
+import { agentMessageToUserMessage, historicalImageSpawnHint, hasOpaqueCollaboration, promoteCollaborationNewTask } from "./subagent-guidance.mjs";
 import { createUsageTee, forEachSseEvent, parseSseData } from "./sse.mjs";
 import { chatCompletionToResponse, pipeChatCompletionStream, responsesToChat } from "./local-chat-bridge.mjs";
 import { MIN_IMAGE_TRANSPORT_WIRE_BYTES } from "./image-transport.mjs";
@@ -487,6 +487,28 @@ export function isCompactV1Request(requestUrl) {
 // compactV2: a Responses request whose last input item is compaction_trigger.
 export function isCompactV2Request(payload) {
   return Array.isArray(payload?.input) && payload.input.at(-1)?.type === "compaction_trigger";
+}
+
+// Codex publishes catalog ids in its picker; any known payload.model is a deliberate
+// session choice and must update modelSelection on every gateway leg - including
+// compact - not only after a normal relay returns client_selected.
+export function syncModelSelectionFromPayload(services, payload, knownModels) {
+  const requested = normalizeLegacySlug(typeof payload?.model === "string" ? payload.model : "", knownModels);
+  if (requested && knownModels?.has(requested) && services.modelSelection) {
+    services.modelSelection.mainModel = requested;
+  }
+  return requested;
+}
+
+export function compactModelForRelay({ config, knownModels, activeModel, requestedModel, fallbackModel }) {
+  const active = activeModel && knownModels?.has(activeModel) ? activeModel : "";
+  const requested = requestedModel && knownModels?.has(requestedModel) ? requestedModel : "";
+  const requestedVision = Boolean(requested && modelEntryFor(config, requested)?.supportsVision);
+  const activeVision = Boolean(active && modelEntryFor(config, active)?.supportsVision);
+  if (requested && requestedVision && !activeVision) return requested;
+  if (active) return active;
+  if (requested) return requested;
+  return fallbackModel || "";
 }
 
 // OpenAI-issued reasoning encrypted_content is an opaque Fernet-style token with
@@ -1012,6 +1034,7 @@ export function normalizeGatewayInput(input) {
   const rewritten = dedupeToolCalls(dropUnpairedToolItems(input))
     .filter((item) => item?.type !== "compaction_trigger")
     .map((item) => {
+      if (item?.type === "agent_message") return agentMessageToUserMessage(item);
       if (item?.type !== "compaction") return item;
       const text = compactionSummaryText(item);
       return {
@@ -1020,7 +1043,8 @@ export function normalizeGatewayInput(input) {
         role: "user",
         content: [{ type: "input_text", text: text || "[Earlier conversation history was compacted in an unreadable format.]" }],
       };
-    });
+    })
+    .filter(Boolean);
   return promoteCollaborationNewTask(rewritten);
 }
 
@@ -3461,12 +3485,17 @@ export async function relayCompaction(payload, res, services, { signal } = {}, v
   const requestedModel = normalizeLegacySlug(typeof payload.model === "string" ? payload.model : "", knownModels);
   if (requestedModel !== payload.model && requestedModel) payload = { ...payload, model: requestedModel };
   const mainModel = mainModelFor(services, sessionId);
-  // A compact is a handoff for the model the user selected, not a new vision
-  // escalation. Keeping a selected vision model matters: it can summarize the
-  // visual evidence in its own long-running conversation.
-  const compactModel = requestedModel && knownModels?.has(requestedModel)
-    ? requestedModel
-    : mainModel;
+  const activeModel = normalizeLegacySlug(
+    services.modelSelection?.mainModel || services.mainModel || mainModel,
+    knownModels,
+  ) || mainModel;
+  const compactModel = compactModelForRelay({
+    config,
+    knownModels,
+    activeModel,
+    requestedModel,
+    fallbackModel: mainModel,
+  });
   const route = {
     model: compactModel,
     reason: "compact_summarize",
@@ -3788,6 +3817,7 @@ export async function relayResponses(payload, res, services, { signal } = {}) {
   mediaStore?.touchSession?.(sessionId);
   const requestedModel = normalizeLegacySlug(typeof payload.model === "string" ? payload.model : "", knownModels);
   if (requestedModel !== payload.model && requestedModel) payload = { ...payload, model: requestedModel };
+  syncModelSelectionFromPayload(services, payload, knownModels);
   if (isNativeModel(requestedModel, knownModels, services.nativeSlugs)) {
     return relayNativeResponses(payload, res, services, { signal });
   }

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -855,6 +855,7 @@ async function relayGatewayRequest(req, res, services) {
       routeAffinity,
       knownModels: publishedModelIds(config),
       nativeSlugs: services.nativeSlugs,
+      modelSelection,
       mainModel: modelSelection?.mainModel || config.mainModel,
       visionModel: modelSelection?.visionModel || config.visionModel,
       // The native passthrough leg forwards these to ChatGPT's backend untouched.

--- a/src/subagent-guidance.mjs
+++ b/src/subagent-guidance.mjs
@@ -81,6 +81,28 @@ export function hasOpaqueCollaboration(input) {
   return null;
 }
 
+// Kimi and other routed providers reject Codex's agent_message item type.
+// Convert readable collaboration-channel content into a plain user message.
+export function agentMessageToUserMessage(item) {
+  if (item?.type !== "agent_message") return item;
+  const text = itemPlainText(item);
+  const payload = newTaskPayloadFromText(text);
+  if (payload) {
+    return {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: payload }],
+    };
+  }
+  if (/Message Type:\s*NEW_TASK\b/i.test(text)) return null;
+  if (!text.trim()) return null;
+  return {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text }],
+  };
+}
+
 export function promoteCollaborationNewTask(input) {
   if (!Array.isArray(input)) return input;
   let payload = "";

--- a/test/gateway.test.mjs
+++ b/test/gateway.test.mjs
@@ -15,6 +15,7 @@ import {
   applyToolPolicy,
   compactFailureReport,
   collaborationRelayCacheSnapshot,
+  compactModelForRelay,
   constrainImagesForTransport,
   createUsageTee,
   decodeCompactionSummary,
@@ -54,6 +55,7 @@ import {
   rewriteHistoricalImages,
   routeGatewayRequest,
   sessionIdsFrom,
+  syncModelSelectionFromPayload,
   stripLocalInstructions,
   upstreamTargetFor,
 } from "../src/gateway.mjs";
@@ -176,8 +178,58 @@ test("normalizeGatewayInput promotes the live split NEW_TASK agent_message shape
     },
     { type: "message", role: "user", content: [{ type: "input_text", text: "<recommended_plugins>\nCanva\n" }] },
   ]);
-  assert.equal(normalized.at(-1).role, "user");
-  assert.equal(normalized.at(-1).content[0].text, payload);
+  assert.equal(normalized.some((item) => item.type === "agent_message"), false);
+  const users = normalized.filter((item) => item.type === "message" && item.role === "user");
+  assert.equal(users.at(-2).content[0].text, payload);
+});
+
+test("normalizeGatewayInput converts agent_message items for routed upstream replay", () => {
+  const normalized = normalizeGatewayInput([
+    {
+      type: "agent_message",
+      content: [{ type: "input_text", text: "status probe complete" }],
+    },
+  ]);
+  assert.deepEqual(normalized, [{
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "status probe complete" }],
+  }]);
+});
+
+test("syncModelSelectionFromPayload updates modelSelection for compact and chat requests", () => {
+  const knownModels = new Set(["k3@kimi", "glm-5.3@zai"]);
+  const services = { modelSelection: { mainModel: "glm-5.3@zai", visionModel: "none" }, mainModel: "glm-5.3@zai" };
+  assert.equal(
+    syncModelSelectionFromPayload(services, { model: "k3@kimi" }, knownModels),
+    "k3@kimi",
+  );
+  assert.equal(services.modelSelection.mainModel, "k3@kimi");
+});
+
+test("compactModelForRelay keeps an explicit vision pick but prefers the active text main over stale payload", () => {
+  const config = configStub();
+  const knownModels = new Set(["deepseek-v4-flash@opencode-go", "mimo-v2.5@opencode-go", "glm-5.3@zai", "k3@kimi"]);
+  assert.equal(
+    compactModelForRelay({
+      config: { ...config, mainModel: "deepseek-v4-flash@opencode-go" },
+      knownModels,
+      activeModel: "deepseek-v4-flash@opencode-go",
+      requestedModel: "mimo-v2.5@opencode-go",
+      fallbackModel: "deepseek-v4-flash@opencode-go",
+    }),
+    "mimo-v2.5@opencode-go",
+  );
+  assert.equal(
+    compactModelForRelay({
+      config: { ...config, mainModel: "deepseek-v4-flash@opencode-go" },
+      knownModels,
+      activeModel: "k3@kimi",
+      requestedModel: "glm-5.3@zai",
+      fallbackModel: "deepseek-v4-flash@opencode-go",
+    }),
+    "k3@kimi",
+  );
 });
 
 test("compaction summaries round-trip through the kcr1 payload", () => {
@@ -3298,6 +3350,92 @@ test("relayCompaction keeps a picked vision model and its image evidence", async
     assert.equal(imagePuts, 1, "compaction derives the image reference once instead of decoding and hashing the same pixels again");
     const compacted = JSON.parse(Buffer.concat(sink.chunks).toString("utf8"));
     assert.match(decodeCompactionSummary(compacted.output[0].encrypted_content), /Image attachment img_compact_visual/, "the compaction handoff keeps a durable image ref");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayCompaction follows the active main model instead of Codex's stale payload.model", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, body: JSON.parse(options.body) });
+    return summaryResponse("kimi compact ok");
+  };
+  try {
+    const result = await relayCompaction(
+      {
+        model: "glm-5.3@zai",
+        stream: false,
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "long task" }] },
+          { type: "compaction_trigger" },
+        ],
+      },
+      res,
+      {
+        ...compactServices(),
+        config: {
+          ...configStub(),
+          mainModel: "deepseek-v4-flash@opencode-go",
+          tokens: { "opencode-go": "go-token", zai: "zai-token", kimi: "kimi-token" },
+        },
+        knownModels: new Set(["glm-5.3@zai", "k3@kimi", "deepseek-v4-flash@opencode-go"]),
+        mainModel: "k3@kimi",
+        modelSelection: { mainModel: "k3@kimi", visionModel: "none" },
+      },
+      {},
+      true,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.route.model, "k3@kimi", "compact must follow the active main model");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].body.model, "k3");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("relayResponses syncs modelSelection on compact_v2 before summarizing", async () => {
+  const sink = collectStream();
+  const res = responseStub(sink);
+  const calls = [];
+  const modelSelection = { mainModel: "deepseek-v4-flash@deepseek-official", visionModel: "none" };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, body: JSON.parse(options.body) });
+    return summaryResponse("kimi compact ok");
+  };
+  try {
+    const result = await relayResponses(
+      {
+        model: "k3@kimi",
+        stream: false,
+        input: [
+          { type: "message", role: "user", content: [{ type: "input_text", text: "long task" }] },
+          { type: "compaction_trigger" },
+        ],
+      },
+      res,
+      {
+        ...compactServices(),
+        config: {
+          ...configStub(),
+          mainModel: "deepseek-v4-flash@deepseek-official",
+          tokens: { "opencode-go": "go-token", "deepseek-official": "ds-token", kimi: "kimi-token" },
+        },
+        knownModels: new Set(["deepseek-v4-flash@deepseek-official", "k3@kimi"]),
+        mainModel: modelSelection.mainModel,
+        modelSelection,
+        requestUrl: "/v1/responses",
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.route.model, "k3@kimi");
+    assert.equal(modelSelection.mainModel, "k3@kimi");
+    assert.equal(calls[0].body.model, "k3");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/test/subagent-guidance.test.mjs
+++ b/test/subagent-guidance.test.mjs
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { promoteCollaborationNewTask, SUBAGENT_SPAWN_RULE, hasOpaqueCollaboration } from "../src/subagent-guidance.mjs";
+import { agentMessageToUserMessage, promoteCollaborationNewTask, SUBAGENT_SPAWN_RULE, hasOpaqueCollaboration } from "../src/subagent-guidance.mjs";
+
+test("agentMessageToUserMessage drops opaque-only agent_message items", () => {
+  assert.equal(agentMessageToUserMessage({
+    type: "agent_message",
+    content: [
+      { type: "input_text", text: "Message Type: NEW_TASK\nPayload:\n" },
+      { type: "encrypted_content", encrypted_content: "gAAAAABopaque_native_cipher_token" },
+    ],
+  }), null);
+});
 
 test("SUBAGENT_SPAWN_RULE uses the managed role without an incompatible full-history fork", () => {
   assert.match(SUBAGENT_SPAWN_RULE, /agent_type="modeldock_subagent"/);


### PR DESCRIPTION
## Summary

- Convert Codex `agent_message` collaboration items to plain user messages before routed upstream replay so Kimi and other non-native backends accept compact histories.
- Sync `modelSelection` on every gateway leg, including `compact_v2`, not only after a normal relay returns `client_selected`.
- Prefer the active main model over stale `payload.model` for compact summarize while still honoring an explicit vision-model compact pick.

## Motivation

Long Codex sessions with spawn/collaboration traffic can carry `agent_message` items that native GPT understands but routed providers reject (`item type "agent_message" is not supported`). Separately, compact summarize could follow a stale `payload.model` instead of the model the user currently has selected in the picker.

## Test plan

- [x] Added/updated unit tests in `test/gateway.test.mjs` and `test/subagent-guidance.test.mjs`
- [x] `node --test test/gateway.test.mjs test/subagent-guidance.test.mjs` (190/190 pass)
- [ ] CI `npm test`


Made with [Cursor](https://cursor.com)